### PR TITLE
marked optional properties to prevent errors

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,6 @@
 .project
 .gradle/
 .settings/
+*.iml
+.idea
+.gradletasknamecache

--- a/src/main/java/org/bitsofinfo/hazelcast/discovery/docker/swarm/DockerSwarmDiscoveryConfiguration.java
+++ b/src/main/java/org/bitsofinfo/hazelcast/discovery/docker/swarm/DockerSwarmDiscoveryConfiguration.java
@@ -6,28 +6,28 @@ import com.hazelcast.config.properties.SimplePropertyDefinition;
 
 /**
  * Defines constants for our supported Properties
- * 
+ *
  * @author bitsofinfo
  *
  */
 public class DockerSwarmDiscoveryConfiguration {
-	
+
 	// comma delimited list of networks to look for services on
-	public static final PropertyDefinition DOCKER_NETWORK_NAMES = 
+	public static final PropertyDefinition DOCKER_NETWORK_NAMES =
 			new SimplePropertyDefinition("docker-network-names", PropertyTypeConverter.STRING);
-	
+
 	// comma delimited list of docker service labels to match
-	public static final PropertyDefinition DOCKER_SERVICE_LABELS = 
-			new SimplePropertyDefinition("docker-service-labels", PropertyTypeConverter.STRING);
-	
+	public static final PropertyDefinition DOCKER_SERVICE_LABELS =
+			new SimplePropertyDefinition("docker-service-labels", true, PropertyTypeConverter.STRING);
+
 	// comma delimited list of docker service names to match
-	public static final PropertyDefinition DOCKER_SERVICE_NAMES = 
+	public static final PropertyDefinition DOCKER_SERVICE_NAMES =
 			new SimplePropertyDefinition("docker-service-names", PropertyTypeConverter.STRING);
-	
+
 	// the configured hazelcast port that all instances are listening on
 	// this is not the published/exposed docker port, but just the hazelcast listening
 	// port that is reachable by any other container on the same overlay network
-	public static final PropertyDefinition HAZELCAST_PEER_PORT = 
-			new SimplePropertyDefinition("hazelcast-peer-port", PropertyTypeConverter.INTEGER);
-	
+	public static final PropertyDefinition HAZELCAST_PEER_PORT =
+			new SimplePropertyDefinition("hazelcast-peer-port", true, PropertyTypeConverter.INTEGER);
+
 }


### PR DESCRIPTION
The plugin currently loads property values in 2 seperate ways:

1. By providing system properties (aka java opts)
2. By passing config properties

I'll send a PR for a unified solution for it but before that we need to make sure that optional properties are marked as optional. This is enforced by `DefaultDiscoverService@187`.