### PR TITLE
Added new constructor to SwarmAddressPicker

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -32,7 +32,7 @@ targetCompatibility = 1.7
 
 dependencies {
     compile group: 'com.hazelcast', name: 'hazelcast', version: '3.8.4'
-    compile group: 'com.spotify', name: 'docker-client', version: '8.9.0'
+    compile group: 'com.spotify', name: 'docker-client', version: '8.9.0', classifier: 'shaded'
 }
 
 bintray {

--- a/build.gradle
+++ b/build.gradle
@@ -1,8 +1,8 @@
 buildscript {
-	repositories {
-    	jcenter()
+    repositories {
+        jcenter()
     }
-    
+
     dependencies {
         classpath 'com.github.jengelman.gradle.plugins:shadow:2.0.1'
     }
@@ -15,15 +15,15 @@ plugins {
 group = 'org.bitsofinfo'
 
 allprojects {
-	repositories {
-		jcenter()
-	}
-	apply plugin: 'maven'
-	apply plugin: 'maven-publish'
-	apply plugin: 'application'
-	apply plugin: 'com.github.johnrengelman.shadow'
-	apply plugin: 'java'
-	
+    repositories {
+        jcenter()
+    }
+    apply plugin: 'maven'
+    apply plugin: 'maven-publish'
+    apply plugin: 'application'
+    apply plugin: 'com.github.johnrengelman.shadow'
+    apply plugin: 'java'
+
     mainClassName = 'org.bitsofinfo.hazelcast.discovery.docker.swarm.test.DockerTestRunner'
 }
 
@@ -31,18 +31,13 @@ sourceCompatibility = 1.7
 targetCompatibility = 1.7
 
 dependencies {
-
-    compile group: 'com.hazelcast', name: 'hazelcast', version:'3.8.2'
-    
-    // https://mvnrepository.com/artifact/com.spotify/docker-client
-    compile group: 'com.spotify', name: 'docker-client', version: '8.7.3', classifier: 'shaded'
-    
-    
+    compile group: 'com.hazelcast', name: 'hazelcast', version: '3.8.4'
+    compile group: 'com.spotify', name: 'docker-client', version: '8.9.0'
 }
 
 bintray {
-	user = project.hasProperty('bintrayUser') ? project.property('bintrayUser') : System.getenv('bintrayUser')
-	key = project.hasProperty('bintrayApiKey') ? project.property('bintrayApiKey') : System.getenv('bintrayApiKey')
+    user = project.hasProperty('bintrayUser') ? project.property('bintrayUser') : System.getenv('bintrayUser')
+    key = project.hasProperty('bintrayApiKey') ? project.property('bintrayApiKey') : System.getenv('bintrayApiKey')
     publications = ['hazelcastDockerSwarmDiscoverySpi']
     pkg {
         repo = 'maven'
@@ -51,11 +46,11 @@ bintray {
         vcsUrl = 'https://github.com/bitsofinfo/hazelcast-docker-swarm-discovery-spi'
         publicDownloadNumbers = true
         version {
-		    name = project.property('version')
-		    desc = project.property('version') + " : " + project.property('description')
-		    released  = new Date()
-		    vcsTag = project.property('version')
-		}
+            name = project.property('version')
+            desc = project.property('version') + " : " + project.property('description')
+            released = new Date()
+            vcsTag = project.property('version')
+        }
     }
 }
 
@@ -78,23 +73,23 @@ task sourcesJar(type: Jar, dependsOn: classes) {
 }
 
 task runTests(type: Test) {
-	description 'Runs unit tests for all tests except TestDoNothingRegistrator.'
-  	
-  	//Always run tests even when up-to-date 
-  	outputs.upToDateWhen { 
-  		false 
-  	}
-	
+    description 'Runs unit tests for all tests except TestDoNothingRegistrator.'
+
+    //Always run tests even when up-to-date
+    outputs.upToDateWhen {
+        false
+    }
+
 }
 
 task unitTest(type: Test) {
-	description 'Runs unit tests for single class.'
-  	
-  	//Always run tests even when up-to-date 
-  	outputs.upToDateWhen { 
-  		false 
-  	}
-  	
+    description 'Runs unit tests for single class.'
+
+    //Always run tests even when up-to-date
+    outputs.upToDateWhen {
+        false
+    }
+
 }
 
 runTests {

--- a/src/main/java/org/bitsofinfo/hazelcast/discovery/docker/swarm/SwarmAddressPicker.java
+++ b/src/main/java/org/bitsofinfo/hazelcast/discovery/docker/swarm/SwarmAddressPicker.java
@@ -7,85 +7,101 @@ import com.hazelcast.logging.ILogger;
 import com.hazelcast.nio.Address;
 
 /**
- * Custom AddressPicker that works for hazelcast
- * instances running in swarm service instances
- * 
+ * Custom AddressPicker that works for hazelcast instances running in swarm service instances
+ * <p>
  * There are four JVM System properties to be defined:
- * 
+ * <p>
  * - dockerNetworkNames = required, min one network: comma delimited list of relevant docker network names
- *                        that matching services must have a VIP on
- *                        
+ * that matching services must have a VIP on
+ * <p>
  * - hazelcastPeerPort = optional, default 5701, the hazelcast port all service members are listening on
- *  
+ * <p>
  * ONE or BOTH of the following can be defined:
- * 
- * - dockerServiceLabels = zero or more comma delimited service 'label=value' pairs to match. 
- *       If ANY match, that services' containers will be included in list of discovered containers
- * 
- * - dockerServiceNames = zero or more comma delimited service "names" to match. 
- *        If ANY match, that services' containers will be included in list of discovered containers
- * 
- * @see https://github.com/hazelcast/hazelcast/issues/10801
- * @author bitsofinfo
+ * <p>
+ * - dockerServiceLabels = zero or more comma delimited service 'label=value' pairs to match.
+ * If ANY match, that services' containers will be included in list of discovered containers
+ * <p>
+ * - dockerServiceNames = zero or more comma delimited service "names" to match.
+ * If ANY match, that services' containers will be included in list of discovered containers
+ * <p>
+ * Another way to initiate this class is to pass above properties when creating a new {@link SwarmAddressPicker}
+ * instance. This eliminates the need to pass properties in both hazelcast.xml (for setting up discovery) and with
+ * JVM properties.
  *
+ * @author bitsofinfo
+ * @see <a href="https://github.com/hazelcast/hazelcast/issues/10801">Hazelcast GitHub Issue #10801</a>
  */
 public class SwarmAddressPicker implements AddressPicker {
-	
-	public static final String PROP_DOCKER_NETWORK_NAMES = "dockerNetworkNames";
-	public static final String PROP_DOCKER_SERVICE_LABELS = "dockerServiceLabels";
-	public static final String PROP_DOCKER_SERVICE_NAMES = "dockerServiceNames";
-	public static final String PROP_HAZELCAST_PEER_PORT = "hazelcastPeerPort";
+    private static final String PROP_DOCKER_NETWORK_NAMES = "dockerNetworkNames";
+    private static final String PROP_DOCKER_SERVICE_LABELS = "dockerServiceLabels";
+    private static final String PROP_DOCKER_SERVICE_NAMES = "dockerServiceNames";
+    private static final String PROP_HAZELCAST_PEER_PORT = "hazelcastPeerPort";
 
-	private SwarmDiscoveryUtil swarmDiscoveryUtil = null;
-	private ILogger logger = null;
+    private SwarmDiscoveryUtil swarmDiscoveryUtil = null;
 
-	/**
-	 * Constructor
-	 */
-	public SwarmAddressPicker(ILogger iLogger) {
-		
-		this.logger = iLogger;
-		
-		String rawDockerNetworkNames = System.getProperty(PROP_DOCKER_NETWORK_NAMES);
-		String rawDockerServiceLabels = System.getProperty(PROP_DOCKER_SERVICE_LABELS);
-		String rawDockerServiceNames = System.getProperty(PROP_DOCKER_SERVICE_NAMES);
-		
-		Integer hazelcastPeerPort = 5701;
-		if (System.getProperty("hazelcastPeerPort") != null) {
-			hazelcastPeerPort = Integer.valueOf(System.getProperty(PROP_HAZELCAST_PEER_PORT));
-		}
-		
-		try {
-			this.swarmDiscoveryUtil = new SwarmDiscoveryUtil(iLogger,
-															 rawDockerNetworkNames,
-															 rawDockerServiceLabels,
-															 rawDockerServiceNames,
-															 hazelcastPeerPort,
-															 true);
-		} catch(Exception e) {
-			throw new RuntimeException("SwarmAddressPicker: Error constructing SwarmDiscoveryUtil: " + e.getMessage(),e);
-		}
-		
-	}
+    /**
+     * Constructor
+     */
+    public SwarmAddressPicker(final ILogger iLogger) {
+        final String dockerNetworkNames = System.getProperty(PROP_DOCKER_NETWORK_NAMES);
+        final String dockerServiceLabels = System.getProperty(PROP_DOCKER_SERVICE_LABELS);
+        final String dockerServiceNames = System.getProperty(PROP_DOCKER_SERVICE_NAMES);
+        final Integer hazelcastPeerPort = Integer.valueOf(System.getProperty(PROP_HAZELCAST_PEER_PORT));
 
-	@Override
-	public void pickAddress() throws Exception {
-		// nothing to do, done in SwarmDiscoveryUtil above
-	}
+        initialize(iLogger, dockerNetworkNames, dockerServiceLabels, dockerServiceNames, hazelcastPeerPort);
+    }
 
-	@Override
-	public Address getBindAddress() {
-		return this.swarmDiscoveryUtil.getMyAddress();
-	}
+    public SwarmAddressPicker(final ILogger iLogger, final String dockerNetworkNames, final String dockerServiceLabels,
+        final String dockerServiceNames, final Integer hazelcastPeerPort) {
 
-	@Override
-	public Address getPublicAddress() {
-		return this.swarmDiscoveryUtil.getMyAddress();
-	}
+        initialize(iLogger, dockerNetworkNames, dockerServiceLabels, dockerServiceNames, hazelcastPeerPort);
+    }
 
-	@Override
-	public ServerSocketChannel getServerSocketChannel() {
-		return this.swarmDiscoveryUtil.getServerSocketChannel();
-	}
+    private void initialize(final ILogger iLogger, final String dockerNetworkNames, final String dockerServiceLabels,
+        final String dockerServiceNames, final Integer hazelcastPeerPort) {
 
+        final int port;
+
+        if (hazelcastPeerPort != null) {
+            port = hazelcastPeerPort;
+        } else {
+            port = 5701;
+        }
+
+        try {
+            this.swarmDiscoveryUtil = new SwarmDiscoveryUtil(
+                iLogger,
+                dockerNetworkNames,
+                dockerServiceLabels,
+                dockerServiceNames,
+                port,
+                true
+            );
+        } catch (final Exception e) {
+            throw new RuntimeException(
+                "SwarmAddressPicker: Error constructing SwarmDiscoveryUtil: " + e.getMessage(),
+                e
+            );
+        }
+    }
+
+    @Override
+    public void pickAddress() throws Exception {
+        // nothing to do, done in SwarmDiscoveryUtil above
+    }
+
+    @Override
+    public Address getBindAddress() {
+        return this.swarmDiscoveryUtil.getMyAddress();
+    }
+
+    @Override
+    public Address getPublicAddress() {
+        return this.swarmDiscoveryUtil.getMyAddress();
+    }
+
+    @Override
+    public ServerSocketChannel getServerSocketChannel() {
+        return this.swarmDiscoveryUtil.getServerSocketChannel();
+    }
 }


### PR DESCRIPTION
There are 3 important changes in this PR:

1. Removed shading for docker-client since it causes `AbstractMethodError` when used in another project.
2. Updated dependencies to their latest version
3. Added a new constructor to SwarmAddressPicker so that it's possible to pass swarm properties without the need for JVM properties. Otherwise one has to define both `hazelcast.xml` properties (as `DefaultDiscoveryService` forces this) and JVM properties.