### PR TITLE
Add Docker Swarm DNSRR Discovery Strategy

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -74,6 +74,55 @@ script:
   
   # Remove the service
   - docker service rm hazelcast-docker-swarm-discovery-spi-test
-  
+
+  # Test Docker Swarm DNSRR discovery
+  - > 
+    docker service create
+    --network hazelcast-docker-swarm-discovery-spi-test
+    --name hazelcast-docker-swarm-dnsrr-discovery-spi-service
+    --endpoint-mode dnsrr
+    hazelcast-docker-swarm-discovery-spi-test
+    java
+    -Dswarm-bind-method=dockerDNSRR
+    -DserviceName=hazelcast-docker-swarm-dnsrr-discovery-spi-service
+    -DservicePort=5701
+    -DpeerServicesCsv=hazelcast-docker-swarm-dnsrr-discovery-spi-service:5701
+    -Dhazelcast.diagnostics.enabled=true
+    -jar /test.jar
+
+  # Wait for startup
+  - docker service ls
+  - sleep 10
+  - docker service logs hazelcast-docker-swarm-dnsrr-discovery-spi-service
+
+  # Dump logs of first container and scale to 10
+  - docker ps
+  - export CONTAINER1_ID=`docker ps -f "name=hazelcast-docker-swarm-dnsrr-discovery-spi-service.1" --format "{{.ID}}"`
+  - docker logs $CONTAINER1_ID
+  - docker service scale hazelcast-docker-swarm-dnsrr-discovery-spi-service=10
+
+  # Let cluster form w/ 10 nodes and verify there are 10 hz members
+  - sleep 80
+  - docker ps
+  - docker logs $CONTAINER1_ID
+  - export CONTAINER10_ID=`docker ps -f "name=hazelcast-docker-swarm-dnsrr-discovery-spi-service.10" --format "{{.ID}}"`
+  - docker logs $CONTAINER10_ID
+  - export MEMBER_TOTAL=`docker logs --tail 150 $CONTAINER1_ID 2>&1 | grep "Members {size:10"`
+  - echo $MEMBER_TOTAL
+  - if [[ "$MEMBER_TOTAL" == 'Members {size:10'* ]]; then echo "OK"; else exit 1; fi
+
+  # Scale cluster down to 2 nodes, wait 2 minutes then verify only 2 nodes
+  - docker service scale hazelcast-docker-swarm-dnsrr-discovery-spi-service=2
+  - sleep 80
+  - docker ps
+  - export CONTAINERX_ID=`docker ps -f "name=hazelcast-docker-swarm-dnsrr-discovery-spi-service." --format "{{.ID}}"`
+  - CONTAINERX_ID=`echo $CONTAINERX_ID | awk '{ print $1 }'`
+  - docker logs --tail 50 $CONTAINERX_ID
+  - export MEMBER_TOTAL=`docker logs --tail 150 $CONTAINERX_ID 2>&1 | grep "Members {size:2"`
+  - echo $MEMBER_TOTAL
+  - if [[ "$MEMBER_TOTAL" == 'Members {size:2'* ]]; then echo "OK"; else exit 1; fi
+
+  - docker service rm hazelcast-docker-swarm-dnsrr-discovery-spi-service
+
 jdk:
   - oraclejdk8

--- a/src/main/java/org/bitsofinfo/hazelcast/discovery/docker/swarm/test/DockerTestRunner.java
+++ b/src/main/java/org/bitsofinfo/hazelcast/discovery/docker/swarm/test/DockerTestRunner.java
@@ -48,8 +48,14 @@ public class DockerTestRunner {
 			
 			HazelcastInstance hazelcastInstance = HazelcastInstanceFactory
 					.newHazelcastInstance(conf,"hazelcast-docker-swarm-discovery-spi-example",new DefaultNodeContext());
-			
-		
+		} else if (System.getProperty("swarm-bind-method").equalsIgnoreCase("dockerDNSRR")) {
+			Config conf =
+				new ClasspathXmlConfig(
+					"hazelcast-docker-swarm-dnsrr-discovery-spi-example.xml"
+				);
+
+			HazelcastInstance hazelcastInstance =
+				HazelcastInstanceFactory.newHazelcastInstance(conf);
 		}
 		
 		

--- a/src/main/java/org/bitsofinfo/hazelcast/spi/docker/swarm/dnsrr/DockerDNSRRMemberAddressProvider.java
+++ b/src/main/java/org/bitsofinfo/hazelcast/spi/docker/swarm/dnsrr/DockerDNSRRMemberAddressProvider.java
@@ -1,0 +1,161 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.bitsofinfo.hazelcast.spi.docker.swarm.dnsrr;
+
+import java.net.InetAddress;
+import java.net.InetSocketAddress;
+import java.net.NetworkInterface;
+import java.net.SocketException;
+import java.net.UnknownHostException;
+import java.util.Arrays;
+import java.util.Enumeration;
+import java.util.HashSet;
+import java.util.Properties;
+import java.util.Set;
+
+import com.hazelcast.logging.ILogger;
+import com.hazelcast.logging.Logger;
+import com.hazelcast.spi.MemberAddressProvider;
+
+/**
+ * Member Address Provider for hazelcast that cross-references the service
+ * name resolution against the loaded networks in-container to determine the
+ * appropriate bind address for the hazelcast instance
+ *
+ * @author Cardds
+ *
+ */
+public class DockerDNSRRMemberAddressProvider
+    implements MemberAddressProvider
+{
+    ILogger logger = Logger.getLogger(DockerDNSRRMemberAddressProvider.class);
+
+    public static Properties properties;
+    public static InetSocketAddress bindAddress = null;
+
+    public DockerDNSRRMemberAddressProvider(Properties properties)
+        throws
+            NumberFormatException,
+            SocketException,
+            UnknownHostException
+    {
+        DockerDNSRRMemberAddressProvider.properties = properties;
+
+        if(properties != null) {
+            String serviceName = properties.getProperty(
+                DockerDNSRRMemberAddressProviderConfig.SERVICENAME
+            );
+            String portString = properties.getProperty(
+                DockerDNSRRMemberAddressProviderConfig.SERVICEPORT
+            );
+            Integer port = 5701;
+
+            if (
+                portString != null &&
+                !"".equals(
+                    portString.trim()
+                )
+            ) {
+                try {
+                    port = Integer.valueOf(portString);
+                } catch(NumberFormatException nfe) {
+                    logger.severe(
+                        "Unable to parse " +
+                        DockerDNSRRMemberAddressProviderConfig.SERVICEPORT +
+                        " with value " +
+                        portString
+                    );
+                    throw nfe;
+                }
+            }
+
+            Set<InetAddress> potentialInetAddresses =
+                resolveServiceName(serviceName);
+
+            Enumeration<NetworkInterface> networkInterfaces;
+            Enumeration<InetAddress> networkInterfaceAddresses;
+            InetAddress address;
+
+            try {
+                networkInterfaces = NetworkInterface.getNetworkInterfaces();
+
+                while(
+                    networkInterfaces.hasMoreElements() &&
+                    bindAddress == null
+                ) {
+                    networkInterfaceAddresses =
+                        networkInterfaces.nextElement().getInetAddresses();
+
+                    while(networkInterfaceAddresses.hasMoreElements()) {
+                        address = networkInterfaceAddresses.nextElement();
+
+                        if(
+                            potentialInetAddresses.contains(address)
+                        ) {
+                            bindAddress = new InetSocketAddress(
+                                address,
+                                port
+                            );
+                            break;
+                        }
+                    }
+                }
+            } catch (SocketException e) {
+                logger.severe(
+                    "Unable to bind socket: " + e.toString()
+                );
+                throw e;
+            }
+
+        }
+    }
+
+    private Set<InetAddress> resolveServiceName(String serviceName)
+        throws UnknownHostException
+    {
+        Set<InetAddress> addresses = new HashSet<InetAddress>();
+
+        try {
+            InetAddress[] inetAddresses;
+            inetAddresses = InetAddress.getAllByName(serviceName);
+
+            addresses.addAll(
+                Arrays.asList(inetAddresses)
+            );
+
+            logger.info(
+                "Resolved domain name '" + serviceName +
+                    "' to address(es): " + addresses
+            );
+        } catch(UnknownHostException e) {
+            logger.severe(
+                "Unable to resolve service name " + serviceName
+            );
+            throw e;
+        }
+
+        return addresses;
+    }
+
+    @Override
+    public InetSocketAddress getBindAddress() {
+        return bindAddress;
+    }
+
+    @Override
+    public InetSocketAddress getPublicAddress() {
+        return bindAddress;
+    }
+}

--- a/src/main/java/org/bitsofinfo/hazelcast/spi/docker/swarm/dnsrr/DockerDNSRRMemberAddressProviderConfig.java
+++ b/src/main/java/org/bitsofinfo/hazelcast/spi/docker/swarm/dnsrr/DockerDNSRRMemberAddressProviderConfig.java
@@ -1,0 +1,36 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.bitsofinfo.hazelcast.spi.docker.swarm.dnsrr;
+
+/**
+ * Configuration for <code>DockerDNSRRMemberAddressProvider</code>
+ *
+ * @author Cardds
+ *
+ */
+public class DockerDNSRRMemberAddressProviderConfig {
+    /**
+     * Property definition to load name of this docker service
+     */
+    public static final String SERVICENAME = "serviceName";
+
+    /**
+     * Property definition to load exposed port for hazelcast
+     * 
+     * Note: This exists because MemberAddressProvider has no way to access
+     *       the network configuration as of the time of writing this.
+     */
+    public static final String SERVICEPORT = "servicePort";
+}

--- a/src/main/java/org/bitsofinfo/hazelcast/spi/docker/swarm/dnsrr/discovery/DockerDNSRRDiscoveryConfiguration.java
+++ b/src/main/java/org/bitsofinfo/hazelcast/spi/docker/swarm/dnsrr/discovery/DockerDNSRRDiscoveryConfiguration.java
@@ -1,0 +1,49 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.bitsofinfo.hazelcast.spi.docker.swarm.dnsrr.discovery;
+
+import java.util.Arrays;
+import java.util.Collection;
+
+import com.hazelcast.config.properties.PropertyDefinition;
+import com.hazelcast.config.properties.PropertyTypeConverter;
+import com.hazelcast.config.properties.SimplePropertyDefinition;
+
+/**
+ * Configuration required for <code>DockerDNSRRDiscoveryStrategy</code>
+ *
+ * @author Cardds
+ *
+ */
+public class DockerDNSRRDiscoveryConfiguration {
+    /**
+     * Property definition to load CSV of services
+     */
+    public static final PropertyDefinition SERVICESCSV =
+        new SimplePropertyDefinition(
+            "peerServicesCsv",
+            PropertyTypeConverter.STRING
+        );
+
+    /**
+     * Full list of all properties referenced by this configuration
+     */
+    public static final Collection<PropertyDefinition> PROPERTIES =
+        Arrays.asList(
+            new PropertyDefinition[] {
+                SERVICESCSV
+            }
+        );
+}

--- a/src/main/java/org/bitsofinfo/hazelcast/spi/docker/swarm/dnsrr/discovery/DockerDNSRRDiscoveryStrategy.java
+++ b/src/main/java/org/bitsofinfo/hazelcast/spi/docker/swarm/dnsrr/discovery/DockerDNSRRDiscoveryStrategy.java
@@ -1,0 +1,163 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.bitsofinfo.hazelcast.spi.docker.swarm.dnsrr.discovery;
+
+import java.net.InetAddress;
+import java.net.UnknownHostException;
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.LinkedList;
+import java.util.Map;
+import java.util.Set;
+
+import com.hazelcast.logging.ILogger;
+import com.hazelcast.nio.Address;
+import com.hazelcast.spi.discovery.AbstractDiscoveryStrategy;
+import com.hazelcast.spi.discovery.DiscoveryNode;
+import com.hazelcast.spi.discovery.SimpleDiscoveryNode;
+
+/**
+ * Hazelcast discovery strategy to be used with docker endpoint_mode: dnsrr
+ * This expects a CSV of peer services and resolves each one to component IP
+ * addresses within the docker network to connect to each individually.
+ *
+ * @author Cardds
+ *
+ */
+public class DockerDNSRRDiscoveryStrategy
+    extends AbstractDiscoveryStrategy
+{
+    private ILogger logger;
+
+    public DockerDNSRRDiscoveryStrategy(
+        ILogger logger,
+        //The Comparable raw type is defined by AbstractDiscoveryStrategy as
+        //the value for the properties element; passing through here
+        @SuppressWarnings("rawtypes") Map<String, Comparable> properties
+    ) {
+        super(logger, properties);
+        this.logger = logger;
+    }
+
+    @Override
+    public Iterable<DiscoveryNode> discoverNodes() {
+        LinkedList<DiscoveryNode> discoveryNodes =
+            new LinkedList<DiscoveryNode>();
+
+        //Pull properties
+        String servicesCsv = getOrDefault(
+            DockerDNSRRDiscoveryConfiguration.SERVICESCSV,
+            ""
+        );
+
+        //If there are no services configured, no point in doing anything.
+        if(
+            servicesCsv == null ||
+            servicesCsv.trim().isEmpty()
+        ) {
+            return discoveryNodes;
+        }
+
+        Set<InetAddress> serviceNameResolutions =
+            new HashSet<InetAddress>();
+        String[] serviceHostnameAndPort;
+        Integer port = 5701;
+
+        //Loop for every service defined in the CSV
+        for(String service: servicesCsv.split(",")) {
+            if(!service.trim().isEmpty()) {
+                //CSV should be composed of hostname:port
+                serviceHostnameAndPort = service.split(":");
+
+                //Validate hostname exists
+                if (
+                    serviceHostnameAndPort[0] == null ||
+                    serviceHostnameAndPort[0].trim().isEmpty()
+                ) {
+                    logger.info(
+                        "Unable to resolve service hostname " +
+                            serviceHostnameAndPort[0] +
+                            " Skipping service entry."
+                    );
+                    continue;
+                }
+                //Validate port exists; assume default port if it doesn't
+                if (
+                    serviceHostnameAndPort.length <= 1 ||
+                    serviceHostnameAndPort[1] == null ||
+                    serviceHostnameAndPort[1].trim().isEmpty()
+                ) {
+                    port = 5701;
+                } else {
+                    try {
+                        port = Integer.valueOf(
+                            serviceHostnameAndPort[1]
+                        );
+                    } catch(NumberFormatException nfe) {
+                        logger.info(
+                            "Unable to parse port " +
+                                serviceHostnameAndPort[1] +
+                                " Skipping service entry."
+                        );
+                        continue;
+                    }
+                }
+
+                //Resolve service hostname to a set of IP addresses, if any
+                serviceNameResolutions =
+                    resolveDomainNames(
+                        serviceHostnameAndPort[0]
+                    );
+
+                //Add all IP addresses for service hostname with the given port.
+                for(InetAddress resolution: serviceNameResolutions) {
+                    discoveryNodes.add(
+                        new SimpleDiscoveryNode(
+                            new Address(
+                                resolution,
+                                port
+                            )
+                        )
+                    );
+                }
+            }
+        }
+
+        return discoveryNodes;
+    }
+
+    private Set<InetAddress> resolveDomainNames(String domainName) {
+        Set<InetAddress> addresses = new HashSet<InetAddress>();
+
+        try {
+            InetAddress[] inetAddresses;
+            inetAddresses = InetAddress.getAllByName(domainName);
+
+            addresses.addAll(
+                Arrays.asList(inetAddresses)
+            );
+
+            logger.info(
+                "Resolved domain name '" + domainName + "' to address(es): " + addresses
+            );
+        } catch(UnknownHostException e) {
+            logger.severe(
+                "Unable to resolve domain name " + domainName
+            );
+        }
+
+        return addresses;
+    }
+}

--- a/src/main/java/org/bitsofinfo/hazelcast/spi/docker/swarm/dnsrr/discovery/DockerDNSRRDiscoveryStrategyFactory.java
+++ b/src/main/java/org/bitsofinfo/hazelcast/spi/docker/swarm/dnsrr/discovery/DockerDNSRRDiscoveryStrategyFactory.java
@@ -1,0 +1,58 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.bitsofinfo.hazelcast.spi.docker.swarm.dnsrr.discovery;
+
+import java.util.Collection;
+import java.util.Map;
+
+import com.hazelcast.config.properties.PropertyDefinition;
+import com.hazelcast.logging.ILogger;
+import com.hazelcast.spi.discovery.DiscoveryNode;
+import com.hazelcast.spi.discovery.DiscoveryStrategy;
+import com.hazelcast.spi.discovery.DiscoveryStrategyFactory;
+
+/**
+ * Factory to produce <code>DockerDNSRRDiscoveryStrategy</code>
+ *
+ * @author Cardds
+ *
+ */
+public class DockerDNSRRDiscoveryStrategyFactory
+    implements DiscoveryStrategyFactory
+{
+    @Override
+    public Class<? extends DiscoveryStrategy> getDiscoveryStrategyType() {
+        return DockerDNSRRDiscoveryStrategy.class;
+    }
+
+    @Override
+    public DiscoveryStrategy newDiscoveryStrategy(
+        DiscoveryNode discoveryNode,
+        ILogger logger,
+        //Implementing DiscoveryStrategyFactory method with a raw type
+        @SuppressWarnings("rawtypes") Map<String, Comparable> properties
+    ) {
+        return
+            new DockerDNSRRDiscoveryStrategy(
+                logger,
+                properties
+            );
+    }
+
+    @Override
+    public Collection<PropertyDefinition> getConfigurationProperties() {
+        return DockerDNSRRDiscoveryConfiguration.PROPERTIES;
+    }
+}

--- a/src/main/resources/META-INF/services/com.hazelcast.spi.discovery.DiscoveryStrategyFactory
+++ b/src/main/resources/META-INF/services/com.hazelcast.spi.discovery.DiscoveryStrategyFactory
@@ -1,1 +1,2 @@
 org.bitsofinfo.hazelcast.discovery.docker.swarm.DockerSwarmDiscoveryStrategyFactory
+org.bitsofinfo.hazelcast.spi.docker.swarm.dnsrr.discovery.DockerDNSRRDiscoveryStrategyFactory

--- a/src/main/resources/hazelcast-docker-swarm-dnsrr-discovery-spi-example.xml
+++ b/src/main/resources/hazelcast-docker-swarm-dnsrr-discovery-spi-example.xml
@@ -5,28 +5,46 @@
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 >
     <properties>
+        <!-- Explicitly enable hazelcast discovery join methods -->
         <property name="hazelcast.discovery.enabled">true</property>
     </properties>
 
     <network>
+        <!--
+            Auto-increment is turned off for the port; docker containers will
+            always be available at the available in-network ports.
+        -->
         <port auto-increment="false">${servicePort}</port>
         <member-address-provider enabled="true">
             <class-name>org.bitsofinfo.hazelcast.spi.docker.swarm.dnsrr.DockerDNSRRMemberAddressProvider</class-name>
             <properties>
+                <!-- Name of the docker service that this instance is running in -->
                 <property name="serviceName">${serviceName}</property>
+
+                <!-- Internal port that hazelcast is listening on -->
                 <property name="servicePort">${servicePort}</property>
             </properties>
         </member-address-provider>
         <join>
+            <!-- Explicitly disable other cluster join methods -->
             <multicast enabled="false"/>
             <aws enabled="false"/>
             <tcp-ip enabled="false" />
+
             <discovery-strategies>
                 <discovery-strategy
                     enabled="true"
                     class="org.bitsofinfo.hazelcast.spi.docker.swarm.dnsrr.discovery.DockerDNSRRDiscoveryStrategy"
                 >
                     <properties>
+                        <!--
+                            Comma separated list of docker services and associated ports 
+                            to be considered peers of this service.
+
+                            Note, this must include itself (the definition of
+                            serviceName and servicePort) if the service is to
+                            cluster with other instances of this service.
+                        -->
                         <property name="peerServicesCsv">${peerServicesCsv}</property>
                     </properties>
                 </discovery-strategy>

--- a/src/main/resources/hazelcast-docker-swarm-dnsrr-discovery-spi-example.xml
+++ b/src/main/resources/hazelcast-docker-swarm-dnsrr-discovery-spi-example.xml
@@ -1,0 +1,36 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<hazelcast
+    xsi:schemaLocation="http://www.hazelcast.com/schema/config hazelcast-config-3.10.xsd"
+    xmlns="http://www.hazelcast.com/schema/config"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+>
+    <properties>
+        <property name="hazelcast.discovery.enabled">true</property>
+    </properties>
+
+    <network>
+        <port auto-increment="false">${servicePort}</port>
+        <member-address-provider enabled="true">
+            <class-name>org.bitsofinfo.hazelcast.spi.docker.swarm.dnsrr.DockerDNSRRMemberAddressProvider</class-name>
+            <properties>
+                <property name="serviceName">${serviceName}</property>
+                <property name="servicePort">${servicePort}</property>
+            </properties>
+        </member-address-provider>
+        <join>
+            <multicast enabled="false"/>
+            <aws enabled="false"/>
+            <tcp-ip enabled="false" />
+            <discovery-strategies>
+                <discovery-strategy
+                    enabled="true"
+                    class="org.bitsofinfo.hazelcast.spi.docker.swarm.dnsrr.discovery.DockerDNSRRDiscoveryStrategy"
+                >
+                    <properties>
+                        <property name="peerServicesCsv">${peerServicesCsv}</property>
+                    </properties>
+                </discovery-strategy>
+            </discovery-strategies>
+        </join>
+    </network>
+</hazelcast>


### PR DESCRIPTION
Adds discovery strategy that relies on endpoint mode being set to
dnsrr in docker, but eliminates the need for addresses of the
swarm manager (and any need for exposing the docker HTTP API port).