### PR TITLE
#13 > dockerServiceNames should be optional

### DIFF
--- a/src/main/java/org/bitsofinfo/hazelcast/discovery/docker/swarm/DockerSwarmDiscoveryConfiguration.java
+++ b/src/main/java/org/bitsofinfo/hazelcast/discovery/docker/swarm/DockerSwarmDiscoveryConfiguration.java
@@ -22,7 +22,7 @@ public class DockerSwarmDiscoveryConfiguration {
 
 	// comma delimited list of docker service names to match
 	public static final PropertyDefinition DOCKER_SERVICE_NAMES =
-			new SimplePropertyDefinition("docker-service-names", PropertyTypeConverter.STRING);
+			new SimplePropertyDefinition("docker-service-names", true, PropertyTypeConverter.STRING);
 
 	// the configured hazelcast port that all instances are listening on
 	// this is not the published/exposed docker port, but just the hazelcast listening


### PR DESCRIPTION
dockerServiceNames should be optional.
Also fixed examples in README.md with incorrect/missing label definitions