### PR TITLE
Dependency version ranges are changed to use Maven-supported syntax

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -31,8 +31,8 @@ sourceCompatibility = 1.7
 targetCompatibility = 1.7
 
 dependencies {
-    compile group: 'com.hazelcast', name: 'hazelcast', version: '3.9.+'
-    compile group: 'com.spotify', name: 'docker-client', version: '8.+', classifier: 'shaded'
+    compile group: 'com.hazelcast', name: 'hazelcast', version: '[3.9,3.10-BETA-1)'
+    compile group: 'com.spotify', name: 'docker-client', version: '[8,9)', classifier: 'shaded'
 }
 
 bintray {


### PR DESCRIPTION
Details: https://github.com/bitsofinfo/hazelcast-docker-swarm-discovery-spi/issues/17
