### PR TITLE
issue_36_serviceCriteria Constrain explicitly on dockerServiceName the results from criteria-based /services request

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -40,7 +40,7 @@ script:
   - echo $MY_IP
   
   # Create the service
-  - docker service create --network hazelcast-docker-swarm-discovery-spi-test --name hazelcast-docker-swarm-discovery-spi-test -e "DOCKER_HOST=http://$MY_IP:2376" hazelcast-docker-swarm-discovery-spi-test java -DdockerNetworkNames=hazelcast-docker-swarm-discovery-spi-test -DdockerServiceNames=hazelcast-docker-swarm-discovery-spi-test -DhazelcastPeerPort=5701 -Dhazelcast.diagnostics.enabled=true -Dswarm-bind-method=member-address-provider -DswarmMgrUri=http://$MY_IP:2376 -DskipVerifySsl=false -DlogAllServiceNamesOnFailedDiscovery=true -Dhazelcast.max.no.heartbeat.seconds=30 -jar /test.jar
+  - docker service create --network hazelcast-docker-swarm-discovery-spi-test --name hazelcast-docker-swarm-discovery-spi-test -e "DOCKER_HOST=http://$MY_IP:2376" hazelcast-docker-swarm-discovery-spi-test java -DdockerNetworkNames=hazelcast-docker-swarm-discovery-spi-test -DdockerServiceNames=hazelcast-docker-swarm-discovery-spi-test -DhazelcastPeerPort=5701 -Dhazelcast.diagnostics.enabled=true -Dswarm-bind-method=member-address-provider -DswarmMgrUri=http://$MY_IP:2376 -DskipVerifySsl=false -DlogAllServiceNamesOnFailedDiscovery=true -DstrictDockerServiceNameComparison=true -Dhazelcast.max.no.heartbeat.seconds=30 -jar /test.jar
   - docker service ls
   - sleep 10
   - docker service logs hazelcast-docker-swarm-discovery-spi-test

--- a/README.md
+++ b/README.md
@@ -30,6 +30,8 @@ This is release candidate code, tested against Hazelcast 3.6-EA+ through 3.9.x S
 
 * MASTER - in progress, this README refers to what is in the master tag. **Switch to relevant RELEASE tag above to see that version's README**
 
+* [1.0-RC14](https://github.com/bitsofinfo/hazelcast-docker-swarm-discovery-spi/releases/tag/1.0-RC14) Additional configurable properties (`strict-docker-service-name-comparison / strictDockerServiceNameComparison`) to optionally add a strict "equals" check against names of services returned from docker; docker itself returns services based on a "startsWith" check.
+
 * [1.0-RC13](https://github.com/bitsofinfo/hazelcast-docker-swarm-discovery-spi/releases/tag/1.0-RC13) Additional configurable properties (`log-all-service-names-on-failed-discovery / logAllServiceNamesOnFailedDiscovery`) to optionally log (FINE) all available docker service names if no containers can be discovered via configured criteria. Better logging to provide the context by which `SwarmDiscoveryUtil` is being utilized.
 
 * [1.0-RC12](https://github.com/bitsofinfo/hazelcast-docker-swarm-discovery-spi/releases/tag/1.0-RC12) Additional debug logging
@@ -241,6 +243,26 @@ docker service create \
     -jar /test.jar
 ```
 
+**1.0-RC14+ ONLY: Optionally, strictDockerServiceNameComparison
+```
+docker service create \
+    --network [mynet] \
+    --name myHzService1 \
+    -l myLabel1=value1 \
+    -l myLabel2=value2 \
+    [yourappimage] \
+    java \
+    -DdockerNetworkNames=[mynet] \
+    -DdockerServiceNames=myHzService1 \
+    -DdockerServiceLabels="myLabel1=value1,myLabel2=value2" \
+    -DhazelcastPeerPort=5701 \
+    -DswarmMgrUri=http(s)://[swarmmgr]:[port] \
+    -DskipVerifySsl=[true|false] \
+    -DlogAllServiceNamesOnFailedDiscovery=[true|false] \
+    -DstrictDockerServiceNameComparison=[true|false] \
+    -jar /test.jar
+```
+
 NOTE! All `-D` java System properties above can be omitted and alternatively defined within the `<member-address-provider>` Hazelcast XML configuration stanza itself. You can mix/match combination of -D defined properties and those defined in Hazelcast XML. Properties defined in Hazelcast XMl take priority.
 
 NOTE! Use the optional `logAllServiceNamesOnFailedDiscovery` property with caution. If your target swarm cluster contains many services this call may result in logging a considerable amount of un-related docker service names.
@@ -283,6 +305,7 @@ For Hazelcast <= 3.8.x apps: see the example: (hazelcast-docker-swarm-discovery-
                 <property name="swarmMgrUri">...</property>
                 <property name="skipVerifySsl">true|false</property>
                 <property name="logAllServiceNamesOnFailedDiscovery">true|false</property>
+                <property name="strictDockerServiceNameComparison">true|false</property>
                 </properties>
             -->
         </member-address-provider>
@@ -317,6 +340,9 @@ For Hazelcast <= 3.8.x apps: see the example: (hazelcast-docker-swarm-discovery-
                        may result in logging a considerable amount of un-related docker service names.
                   -->
                   <property name="log-all-service-names-on-failed-discovery">${logAllServiceNamesOnFailedDiscovery}</property>
+
+                  <!-- 1.0-RC14+ ONLY: If enabled, perform strict "equals" name check of services returned from Docker -->
+                  <property name="strict-docker-service-name-comparison">${strictDockerServiceNameComparison}</property>
 
                   <!-- The raw port that hazelcast is listening on
 

--- a/src/main/java/org/bitsofinfo/hazelcast/discovery/docker/swarm/DockerSwarmDiscoveryConfiguration.java
+++ b/src/main/java/org/bitsofinfo/hazelcast/discovery/docker/swarm/DockerSwarmDiscoveryConfiguration.java
@@ -42,4 +42,8 @@ public class DockerSwarmDiscoveryConfiguration {
 	public static final PropertyDefinition LOG_ALL_SERVICE_NAMES_ON_FAILED_DISCOVERY =
 			new SimplePropertyDefinition("log-all-service-names-on-failed-discovery", true, PropertyTypeConverter.BOOLEAN);
 
+	// Strict service name "equals" check
+	public static final PropertyDefinition STRICT_DOCKER_SERVICE_NAME_COMPARISON =
+			new SimplePropertyDefinition("strict-docker-service-name-comparison", true, PropertyTypeConverter.BOOLEAN);
+
 }

--- a/src/main/java/org/bitsofinfo/hazelcast/discovery/docker/swarm/DockerSwarmDiscoveryStrategy.java
+++ b/src/main/java/org/bitsofinfo/hazelcast/discovery/docker/swarm/DockerSwarmDiscoveryStrategy.java
@@ -44,7 +44,8 @@ public class DockerSwarmDiscoveryStrategy extends AbstractDiscoveryStrategy {
 		String swarmMgrUri = getOrDefault("swarm-mgr-uri",  DockerSwarmDiscoveryConfiguration.SWARM_MGR_URI, null);
 		Boolean skipVerifySsl = getOrDefault("skip-verify-ssl",  DockerSwarmDiscoveryConfiguration.SKIP_VERIFY_SSL, false);
 		Boolean logAllServiceNamesOnFailedDiscovery = getOrDefault("log-all-service-names-on-failed-discovery",  DockerSwarmDiscoveryConfiguration.LOG_ALL_SERVICE_NAMES_ON_FAILED_DISCOVERY, false);
-		
+		Boolean strictDockerServiceNameComparison = getOrDefault("strict-docker-service-name-comparison", DockerSwarmDiscoveryConfiguration.STRICT_DOCKER_SERVICE_NAME_COMPARISON, false);
+
 		try {
 			
 			URI swarmMgr = null;
@@ -62,7 +63,8 @@ public class DockerSwarmDiscoveryStrategy extends AbstractDiscoveryStrategy {
 															 false, // dont bind channel, the AddressPicker does this
 															 swarmMgr,
 															 skipVerifySsl,
-															 logAllServiceNamesOnFailedDiscovery); 
+															 logAllServiceNamesOnFailedDiscovery,
+															 strictDockerServiceNameComparison);
 		} catch(Exception e) {
 			String msg = "Unexpected error configuring SwarmDiscoveryUtil: " + e.getMessage();
 			logger.severe(msg,e);

--- a/src/main/java/org/bitsofinfo/hazelcast/discovery/docker/swarm/SwarmAddressPicker.java
+++ b/src/main/java/org/bitsofinfo/hazelcast/discovery/docker/swarm/SwarmAddressPicker.java
@@ -103,7 +103,8 @@ public class SwarmAddressPicker implements AddressPicker {
                 true,
                 swarmMgr,
                 skipVerifySsl,
-                false 
+                false,
+                false
             );
         } catch (final Exception e) {
             throw new RuntimeException(

--- a/src/main/java/org/bitsofinfo/hazelcast/discovery/docker/swarm/SwarmDiscoveryUtil.java
+++ b/src/main/java/org/bitsofinfo/hazelcast/discovery/docker/swarm/SwarmDiscoveryUtil.java
@@ -73,6 +73,7 @@ public class SwarmDiscoveryUtil {
 	private boolean skipVerifySsl = false;
 
 	private boolean logAllServiceNamesOnFailedDiscovery = false;
+	private boolean strictDockerServiceNameComparison = false;
 
 	// Since SwarmDiscoveryUtil is used by several components
 	// the context lets us distinguish instances in logs
@@ -86,7 +87,8 @@ public class SwarmDiscoveryUtil {
 							  String rawDockerServiceNames,
 							  Integer hazelcastPeerPort,
 							  boolean bindSocketChannel,
-							  boolean logAllServiceNamesOnFailedDiscovery) throws Exception {
+							  boolean logAllServiceNamesOnFailedDiscovery,
+							  boolean strictDockerServiceNameComparison) throws Exception {
 
 		this(context,
 				rawDockerNetworkNames,
@@ -96,7 +98,8 @@ public class SwarmDiscoveryUtil {
 				bindSocketChannel,
 				new URI(System.getenv("DOCKER_HOST")),
 				false,
-				logAllServiceNamesOnFailedDiscovery);
+				logAllServiceNamesOnFailedDiscovery,
+				strictDockerServiceNameComparison);
 
 	}
 
@@ -108,12 +111,14 @@ public class SwarmDiscoveryUtil {
 							  boolean bindSocketChannel,
 							  URI swarmMgrUri,
 							  boolean skipVerifySsl,
-							  boolean logAllServiceNamesOnFailedDiscovery) throws Exception {
+							  boolean logAllServiceNamesOnFailedDiscovery,
+							  boolean strictDockerServiceNameComparison) throws Exception {
 
 		this.context = context;
 		this.swarmMgrUri = swarmMgrUri;
 		this.skipVerifySsl = skipVerifySsl;
 		this.logAllServiceNamesOnFailedDiscovery = logAllServiceNamesOnFailedDiscovery;
+		this.strictDockerServiceNameComparison = strictDockerServiceNameComparison;
 
 
 		if (this.swarmMgrUri == null) {
@@ -319,6 +324,7 @@ public class SwarmDiscoveryUtil {
 			sb.append("swarmMgrUri = " + this.swarmMgrUri + "\n");
 			sb.append("skipVerifySsl = " + this.skipVerifySsl + "\n");
 			sb.append("logAllServiceNamesOnFailedDiscovery = " + this.logAllServiceNamesOnFailedDiscovery + "\n");
+			sb.append("strictDockerServiceNameComparison = " + this.strictDockerServiceNameComparison + "\n");
 			logger.info(sb.toString());
 
 			// our discovered containers
@@ -471,8 +477,8 @@ public class SwarmDiscoveryUtil {
 
 		for (Service service : services) {
 
-			if(serviceFilter.reject(service)) {
-				logger.fine("service with name " + service.spec().name() + " rejected by filter " + serviceFilter);
+			if(strictDockerServiceNameComparison && serviceFilter.reject(service)) {
+				logger.fine("Service with name " + service.spec().name() + " rejected by filter " + serviceFilter);
 			}
 			else {
 				logger.fine("SwarmDiscoveryUtil[" + this.context + "] Processing service with name=" + service.spec().name());

--- a/src/main/java/org/bitsofinfo/hazelcast/discovery/docker/swarm/SwarmDiscoveryUtil.java
+++ b/src/main/java/org/bitsofinfo/hazelcast/discovery/docker/swarm/SwarmDiscoveryUtil.java
@@ -33,6 +33,9 @@ import com.spotify.docker.client.messages.swarm.Service.Criteria;
 import com.spotify.docker.client.messages.swarm.Task;
 import com.spotify.docker.client.messages.swarm.TaskStatus;
 import com.spotify.docker.client.shaded.com.google.common.collect.ImmutableList;
+import org.bitsofinfo.hazelcast.discovery.docker.swarm.filter.NameBasedServiceFilter;
+import org.bitsofinfo.hazelcast.discovery.docker.swarm.filter.NullServiceFilter;
+import org.bitsofinfo.hazelcast.discovery.docker.swarm.filter.ServiceFilter;
 
 import java.net.SocketException;
 
@@ -45,74 +48,74 @@ import java.net.SocketException;
  *
  */
 public class SwarmDiscoveryUtil {
-	
+
 	// from: https://github.com/hazelcast/hazelcast/blob/210475c806328c6655ea551f6fc59ef8220b601d/hazelcast/src/main/java/com/hazelcast/instance/DefaultAddressPicker.java
 	private static final int SOCKET_TIMEOUT_MILLIS = (int) TimeUnit.SECONDS.toMillis(1);
 	private static final int SOCKET_BACKLOG_LENGTH = 100;
-	
+
 	private Set<String> dockerNetworkNames = new TreeSet<String>(String.CASE_INSENSITIVE_ORDER);
-	private Map<String,String> dockerServiceLabels = new TreeMap<String,String>(String.CASE_INSENSITIVE_ORDER);
+	private Map<String, String> dockerServiceLabels = new TreeMap<String, String>(String.CASE_INSENSITIVE_ORDER);
 	private Set<String> dockerServiceNames = new TreeSet<String>(String.CASE_INSENSITIVE_ORDER);
-	
+
 	private String rawDockerNetworkNames = null;
 	private String rawDockerServiceLabels = null;
 	private String rawDockerServiceNames = null;
-	
+
 	private Integer hazelcastPeerPort = 5701;
-	
+
 	private DiscoveredContainer myContainer = null;
 	private Address myAddress = null;
-	
+
 	private boolean bindSocketChannel = true;
 	private ServerSocketChannel serverSocketChannel = null;
-	
+
 	private URI swarmMgrUri = null;
 	private boolean skipVerifySsl = false;
-	
+
 	private boolean logAllServiceNamesOnFailedDiscovery = false;
-	
+
 	// Since SwarmDiscoveryUtil is used by several components
 	// the context lets us distinguish instances in logs
 	private String context = null;
-	
+
 	private ILogger logger = Logger.getLogger(SwarmDiscoveryUtil.class);
-	
+
 	public SwarmDiscoveryUtil(String context,
-							 String rawDockerNetworkNames, 
-						      String rawDockerServiceLabels,
-							  String rawDockerServiceNames, 
+							  String rawDockerNetworkNames,
+							  String rawDockerServiceLabels,
+							  String rawDockerServiceNames,
 							  Integer hazelcastPeerPort,
 							  boolean bindSocketChannel,
 							  boolean logAllServiceNamesOnFailedDiscovery) throws Exception {
-		
-		this(context, 
-			 rawDockerNetworkNames,
-			 rawDockerServiceLabels,
-			 rawDockerServiceNames,
-			 hazelcastPeerPort,
-			 bindSocketChannel,
-			 new URI(System.getenv("DOCKER_HOST")),
-			 false,
-			 logAllServiceNamesOnFailedDiscovery);
-		
+
+		this(context,
+				rawDockerNetworkNames,
+				rawDockerServiceLabels,
+				rawDockerServiceNames,
+				hazelcastPeerPort,
+				bindSocketChannel,
+				new URI(System.getenv("DOCKER_HOST")),
+				false,
+				logAllServiceNamesOnFailedDiscovery);
+
 	}
-	
+
 	public SwarmDiscoveryUtil(String context,
-							  String rawDockerNetworkNames, 
-						      String rawDockerServiceLabels,
-							  String rawDockerServiceNames, 
+							  String rawDockerNetworkNames,
+							  String rawDockerServiceLabels,
+							  String rawDockerServiceNames,
 							  Integer hazelcastPeerPort,
 							  boolean bindSocketChannel,
 							  URI swarmMgrUri,
 							  boolean skipVerifySsl,
 							  boolean logAllServiceNamesOnFailedDiscovery) throws Exception {
-		
+
 		this.context = context;
 		this.swarmMgrUri = swarmMgrUri;
 		this.skipVerifySsl = skipVerifySsl;
 		this.logAllServiceNamesOnFailedDiscovery = logAllServiceNamesOnFailedDiscovery;
-		
-		
+
+
 		if (this.swarmMgrUri == null) {
 			if (System.getenv("DOCKER_HOST") != null && System.getenv("DOCKER_HOST").trim().isEmpty()) {
 				this.swarmMgrUri = new URI(System.getenv("DOCKER_HOST"));
@@ -132,7 +135,7 @@ public class SwarmDiscoveryUtil {
 				}
 			}
 		} else {
-			String msg = "SwarmDiscoveryUtil["+this.context+"]() You must specify at least one value for 'docker-network-names'";
+			String msg = "SwarmDiscoveryUtil[" + this.context + "]() You must specify at least one value for 'docker-network-names'";
 			throw new Exception(msg);
 		}
 
@@ -140,9 +143,9 @@ public class SwarmDiscoveryUtil {
 			for (String rawElement : rawDockerServiceLabels.split(",")) {
 				if (!rawElement.trim().isEmpty() && rawElement.indexOf('=') != -1) {
 					String[] labelVal = rawElement.split("=");
-					dockerServiceLabels.put(labelVal[0].trim(),labelVal[1].trim());
+					dockerServiceLabels.put(labelVal[0].trim(), labelVal[1].trim());
 				}
-			}	
+			}
 		}
 
 		if (rawDockerServiceNames != null && !rawDockerServiceNames.trim().isEmpty()) {
@@ -155,69 +158,69 @@ public class SwarmDiscoveryUtil {
 
 		// invalid setup
 		if (dockerServiceLabels.size() == 0 && dockerServiceNames.size() == 0) {
-			String msg = "SwarmDiscoveryUtil["+this.context+"]() You must specify at least one value for "
+			String msg = "SwarmDiscoveryUtil[" + this.context + "]() You must specify at least one value for "
 					+ "either 'docker-service-names' or 'docker-service-labels'";
 			throw new Exception(msg);
 		}
-		
+
 		// discover self
 		discoverSelf();
 	}
-	
-	
+
+
 	private void discoverSelf() throws Exception {
-		
+
 		Set<DiscoveredContainer> discoveredContainers = this.discoverContainers();
-		
-		Map<String,DiscoveredContainer> ip2ContainerMap = new HashMap<String,DiscoveredContainer>();
+
+		Map<String, DiscoveredContainer> ip2ContainerMap = new HashMap<String, DiscoveredContainer>();
 		for (DiscoveredContainer dc : discoveredContainers) {
 			ip2ContainerMap.put(dc.getIp(), dc);
 		}
-		
-		Enumeration<NetworkInterface> networkInterfaces = NetworkInterface.getNetworkInterfaces();
-        while (networkInterfaces.hasMoreElements()) {
-            NetworkInterface ni = networkInterfaces.nextElement();
-            Enumeration<InetAddress> e = ni.getInetAddresses();
-            while (e.hasMoreElements()) {
-                InetAddress inetAddress = e.nextElement();
-                
-                DiscoveredContainer dc = ip2ContainerMap.get(inetAddress.getHostAddress());
-                
-                // found myself..
-                if (dc != null) {
-                	
-                	// set local references
-                	this.myContainer = dc;
-                	this.myAddress = new Address(myContainer.getIp(), this.getHazelcastPeerPort());
-                	
-                	if (bindSocketChannel) {
-                		
-	                	// configure ServerSocketChannel
-	                	this.serverSocketChannel = ServerSocketChannel.open();
-	                    ServerSocket serverSocket = serverSocketChannel.socket();
-	                    serverSocket.setReuseAddress(true);
-	                    serverSocket.setSoTimeout(SOCKET_TIMEOUT_MILLIS);
-	                    
-	                    
-	                    try {
-	                    	InetSocketAddress inetSocketAddress = new InetSocketAddress(this.myAddress.getHost(), this.getHazelcastPeerPort());
-	                        logger.info("SwarmDiscoveryUtil["+this.context+"] Trying to bind inet socket address: " + inetSocketAddress);
-	                        serverSocket.bind(inetSocketAddress, SOCKET_BACKLOG_LENGTH);
-	                        logger.info("SwarmDiscoveryUtil["+this.context+"] Bind successful to inet socket address: " + serverSocket.getLocalSocketAddress());
-	                        this.serverSocketChannel.configureBlocking(false);
-	                        
-	                    } catch (Exception e2) {
-	                        serverSocket.close();
-	                        serverSocketChannel.close();
-	                        throw new HazelcastException(e2.getMessage(), e2);
-	                    }
-                	}
 
-                	break;
-                }
-            }
-        }
-		
+		Enumeration<NetworkInterface> networkInterfaces = NetworkInterface.getNetworkInterfaces();
+		while (networkInterfaces.hasMoreElements()) {
+			NetworkInterface ni = networkInterfaces.nextElement();
+			Enumeration<InetAddress> e = ni.getInetAddresses();
+			while (e.hasMoreElements()) {
+				InetAddress inetAddress = e.nextElement();
+
+				DiscoveredContainer dc = ip2ContainerMap.get(inetAddress.getHostAddress());
+
+				// found myself..
+				if (dc != null) {
+
+					// set local references
+					this.myContainer = dc;
+					this.myAddress = new Address(myContainer.getIp(), this.getHazelcastPeerPort());
+
+					if (bindSocketChannel) {
+
+						// configure ServerSocketChannel
+						this.serverSocketChannel = ServerSocketChannel.open();
+						ServerSocket serverSocket = serverSocketChannel.socket();
+						serverSocket.setReuseAddress(true);
+						serverSocket.setSoTimeout(SOCKET_TIMEOUT_MILLIS);
+
+
+						try {
+							InetSocketAddress inetSocketAddress = new InetSocketAddress(this.myAddress.getHost(), this.getHazelcastPeerPort());
+							logger.info("SwarmDiscoveryUtil[" + this.context + "] Trying to bind inet socket address: " + inetSocketAddress);
+							serverSocket.bind(inetSocketAddress, SOCKET_BACKLOG_LENGTH);
+							logger.info("SwarmDiscoveryUtil[" + this.context + "] Bind successful to inet socket address: " + serverSocket.getLocalSocketAddress());
+							this.serverSocketChannel.configureBlocking(false);
+
+						} catch (Exception e2) {
+							serverSocket.close();
+							serverSocketChannel.close();
+							throw new HazelcastException(e2.getMessage(), e2);
+						}
+					}
+
+					break;
+				}
+			}
+		}
+
 	}
 
 
@@ -289,27 +292,27 @@ public class SwarmDiscoveryUtil {
 	public void setHazelcastPeerPort(Integer hazelcastPeerPort) {
 		this.hazelcastPeerPort = hazelcastPeerPort;
 	}
-	
+
 	public Set<DiscoveredContainer> discoverContainers() throws Exception {
-		
+
 		try {
 
 			// our client
 			DockerClient docker = null;
-			
+
 			Builder dockerBuilder = DefaultDockerClient.fromEnv();
-			
+
 			if (skipVerifySsl) {
 				dockerBuilder.dockerCertificates(new SkipVerifyDockerCertificatesStore());
 			}
-			
+
 			if (this.swarmMgrUri != null) {
 				dockerBuilder.uri(this.swarmMgrUri);
 			}
-					
+
 			docker = dockerBuilder.build();
-			
-			StringBuffer sb = new StringBuffer("SwarmDiscoveryUtil["+this.context+"].discoverNodes(): via DOCKER_HOST: " + docker.getHost() + "\n");
+
+			StringBuffer sb = new StringBuffer("SwarmDiscoveryUtil[" + this.context + "].discoverNodes(): via DOCKER_HOST: " + docker.getHost() + "\n");
 			sb.append("docker-network-names = " + this.getRawDockerNetworkNames() + "\n");
 			sb.append("docker-service-names = " + this.getRawDockerServiceNames() + "\n");
 			sb.append("docker-service-labels = " + this.getRawDockerServiceLabels() + "\n");
@@ -322,49 +325,48 @@ public class SwarmDiscoveryUtil {
 			Set<DiscoveredContainer> discoveredContainers = new HashSet<DiscoveredContainer>();
 
 			// the relevant networks we are looking for
-			Map<String,Network> relevantNetIds2Networks = new TreeMap<String,Network>(String.CASE_INSENSITIVE_ORDER);
+			Map<String, Network> relevantNetIds2Networks = new TreeMap<String, Network>(String.CASE_INSENSITIVE_ORDER);
 
 			// build list of relevant networkIds -> Network objects we care about
 			for (String dockerNetworkName : this.getDockerNetworkNames()) {
 				List<Network> networks = docker.listNetworks(ListNetworksParam.byNetworkName(dockerNetworkName));
 				for (Network network : networks) {
-					relevantNetIds2Networks.put(network.id(),network);
-					logger.info("SwarmDiscoveryUtil["+this.context+"] Found relevant docker network: " + network.name() +"["+ network.id() + "]");
+					relevantNetIds2Networks.put(network.id(), network);
+					logger.info("SwarmDiscoveryUtil[" + this.context + "] Found relevant docker network: " + network.name() + "[" + network.id() + "]");
 				}
 			}
-			
-	        if(relevantNetIds2Networks.size() == 0) {
-	            logger.warning("SwarmDiscoveryUtil["+this.context+"] Did not find relevant docker network for: " + this.getDockerNetworkNames());
-	        }
+
+			if (relevantNetIds2Networks.size() == 0) {
+				logger.warning("SwarmDiscoveryUtil[" + this.context + "] Did not find relevant docker network for: " + this.getDockerNetworkNames());
+			}
 
 			// Collect all relevant containers for services with services-names on the relevant networks
 			for (String dockerServiceName : this.getDockerServiceNames()) {
-				logger.info("SwarmDiscoveryUtil["+this.context+"] Invoking criteria-based container discovery for dockerServiceName=" + dockerServiceName);
+				logger.info("SwarmDiscoveryUtil[" + this.context + "] Invoking criteria-based container discovery for dockerServiceName=" + dockerServiceName);
 				discoveredContainers.addAll(
 						discoverContainersViaCriteria(docker,
-										   relevantNetIds2Networks,
-										   Criteria.builder().serviceName(dockerServiceName).build()));
+								relevantNetIds2Networks,
+								Criteria.builder().serviceName(dockerServiceName).build(),
+								new NameBasedServiceFilter(dockerServiceName)));
 			}
-			
-			
+
+
 			// Collect all relevant containers for services matching the labels on the relevant networks
 			for (String dockerServiceLabel : this.getDockerServiceLabels().keySet()) {
 				String labelValue = this.getDockerServiceLabels().get(dockerServiceLabel);
-				logger.info("SwarmDiscoveryUtil["+this.context+"] Invoking criteria-based container discovery for service label: "+ dockerServiceLabel + "=" + labelValue);
+				logger.info("SwarmDiscoveryUtil[" + this.context + "] Invoking criteria-based container discovery for service label: " + dockerServiceLabel + "=" + labelValue);
 				discoveredContainers.addAll(
 						discoverContainersViaCriteria(docker,
-										   relevantNetIds2Networks,
-										   Criteria.builder().addLabel(dockerServiceLabel, labelValue).build()));
+								relevantNetIds2Networks,
+								Criteria.builder().addLabel(dockerServiceLabel, labelValue).build()));
 			}
 
-			
-			
 			// Optionally dump all available services names when configured criteria
 			// yields zero containers
 			if (discoveredContainers.size() == 0 && logAllServiceNamesOnFailedDiscovery) {
 				try {
 					List<Service> allServices = docker.listServices();
-					
+
 					StringBuilder sb2 = new StringBuilder();
 					if (allServices != null) {
 						String delim = "";
@@ -373,137 +375,161 @@ public class SwarmDiscoveryUtil {
 							delim = ",";
 						}
 					}
-					
-					logger.fine("SwarmDiscoveryUtil["+this.context+"] discoveredContainers.size()=0; logAllServiceNamesOnFailedDiscovery=true, "
+
+					logger.fine("SwarmDiscoveryUtil[" + this.context + "] discoveredContainers.size()=0; logAllServiceNamesOnFailedDiscovery=true, "
 							+ "ALL available docker service names=[" + sb2.toString() + "]");
-					
-				} catch(Throwable e) {
-					logger.warning("SwarmDiscoveryUtil["+this.context+"] Unexpected error in logAllServiceNamesOnFailedDiscovery=true handling:" + e.getMessage(),e);
+
+				} catch (Throwable e) {
+					logger.warning("SwarmDiscoveryUtil[" + this.context + "] Unexpected error in logAllServiceNamesOnFailedDiscovery=true handling:" + e.getMessage(), e);
 				}
 			}
-			
+
 			return discoveredContainers;
 
-		} catch(Exception e) {
-			throw new Exception("SwarmDiscoveryUtil["+this.context+"].discoverContainers() unexpected error: " + e.getMessage(),e);
+		} catch (Exception e) {
+			throw new Exception("SwarmDiscoveryUtil[" + this.context + "].discoverContainers() unexpected error: " + e.getMessage(), e);
 		}
 	}
-	
+
 	/**
 	 * Test the {@link NetworkAttachment} against the local {@link NetworkInterface}s.
-	 * This returns true if the {@link NetworkAttachment} contains an address that is 
+	 * This returns true if the {@link NetworkAttachment} contains an address that is
 	 * in {@link NetworkInterface#getNetworkInterfaces()}
-	 * 
-	 * @param networkAttachment 
+	 *
+	 * @param networkAttachment
 	 * @return true if the given {@link NetworkAttachment} is this local node
-	 * @throws SocketException 
+	 * @throws SocketException
 	 */
-	private boolean isSelf(NetworkAttachment networkAttachment) throws SocketException{
-	  for(String addrWithSubnet : networkAttachment.addresses()){
-		String addr = addrWithSubnet.split("/")[0];
-		Enumeration<NetworkInterface> networkInterfaces = NetworkInterface.getNetworkInterfaces();
-        while (networkInterfaces.hasMoreElements()) {
-            NetworkInterface ni = networkInterfaces.nextElement();
-            Enumeration<InetAddress> e = ni.getInetAddresses();
-            while (e.hasMoreElements()) {
-                InetAddress inetAddress = e.nextElement();
-				//Split the networkAttachment address by the "/" since it contains the subnet
-				if(inetAddress.getHostAddress().equals(addr)){
-				  return true;
+	private boolean isSelf(NetworkAttachment networkAttachment) throws SocketException {
+		for (String addrWithSubnet : networkAttachment.addresses()) {
+			String addr = addrWithSubnet.split("/")[0];
+			Enumeration<NetworkInterface> networkInterfaces = NetworkInterface.getNetworkInterfaces();
+			while (networkInterfaces.hasMoreElements()) {
+				NetworkInterface ni = networkInterfaces.nextElement();
+				Enumeration<InetAddress> e = ni.getInetAddresses();
+				while (e.hasMoreElements()) {
+					InetAddress inetAddress = e.nextElement();
+					//Split the networkAttachment address by the "/" since it contains the subnet
+					if (inetAddress.getHostAddress().equals(addr)) {
+						return true;
+					}
 				}
 			}
 		}
-	  }
-	  return false;
+		return false;
 	}
-	
+
 	/**
 	 * Discover containers on the relevant networks that match the given
-	 * service criteria. 
-	 * 
+	 * service criteria, using additionally a NullServiceFilter
+	 *
 	 * @param docker
 	 * @param relevantNetIds2Networks
 	 * @param criteria
 	 * @return set of DiscoveredContainer instances
 	 * @throws Exception
 	 */
+	private Set<DiscoveredContainer> discoverContainersViaCriteria(DockerClient docker,
+																   Map<String,Network> relevantNetIds2Networks,
+																   Service.Criteria criteria) throws Exception {
+		// no ServiceFilter provided, so use one with no constraints
+		return discoverContainersViaCriteria(docker, relevantNetIds2Networks, criteria, NullServiceFilter.getInstance());
+	}
+
+	/**
+	 * Discover containers on the relevant networks that match the given
+	 * service criteria and service filter
+	 * 
+	 * @param docker
+	 * @param relevantNetIds2Networks
+	 * @param criteria to be passed as a parameter to the /services request
+	 * @param serviceFilter additional criteria to be applied to Services returned from the /services request
+	 * @return set of DiscoveredContainer instances
+	 * @throws Exception
+	 */
 	private Set<DiscoveredContainer> discoverContainersViaCriteria(DockerClient docker, 
 			Map<String,Network> relevantNetIds2Networks, 
-			Service.Criteria criteria) throws Exception {
+			Service.Criteria criteria,
+			ServiceFilter serviceFilter) throws Exception {
 
 		Set<DiscoveredContainer> discoveredContainers = new HashSet<DiscoveredContainer>();
 
 		// find all relevant services given the criteria....
 		List<Service> services = docker.listServices(criteria);
-		
+
 		if (services == null) {
-			logger.info("SwarmDiscoveryUtil["+this.context+"] No service match for given criteria, docker.listServices(criteria) returned null.");
+			logger.fine("SwarmDiscoveryUtil[" + this.context + "] No service match for given criteria, docker.listServices(criteria) returned null.");
 			return discoveredContainers;
 		}
- 
+
 		if (services.size() == 0) {
-			logger.info("SwarmDiscoveryUtil["+this.context+"] No service match for given criteria, docker.listServices(criteria) returned 0");
+			logger.fine("SwarmDiscoveryUtil[" + this.context + "] No service match for given criteria, docker.listServices(criteria) returned 0");
 			return discoveredContainers;
 		}
-			
-		logger.info("SwarmDiscoveryUtil["+this.context+"] Number of services matching given criteria = " + services.size());
+
+		logger.fine("SwarmDiscoveryUtil[" + this.context + "] Number of services matching given criteria = " + services.size());
 
 		for (Service service : services) {
 
-			logger.info("SwarmDiscoveryUtil["+this.context+"] Processing service with name=" + service.spec().name());
+			if(serviceFilter.reject(service)) {
+				logger.fine("service with name " + service.spec().name() + " rejected by filter " + serviceFilter);
+			}
+			else {
+				logger.fine("SwarmDiscoveryUtil[" + this.context + "] Processing service with name=" + service.spec().name());
 
-			// crawl through all VIPs the service is on
-			for (EndpointVirtualIp vip : service.endpoint().virtualIps()) {
+				// crawl through all VIPs the service is on
+				for (EndpointVirtualIp vip : service.endpoint().virtualIps()) {
 
-				logger.info("SwarmDiscoveryUtil["+this.context+"] Processing service endpoint with networkId=" + vip.networkId() + ", addr=" + vip.addr());
+					logger.fine("SwarmDiscoveryUtil[" + this.context + "] Processing service endpoint with networkId=" + vip.networkId() + ", addr=" + vip.addr() + " for service with name=" + service.spec().name());
 
-				// does the service have a VIP on one of the networks we care about?
-				if (relevantNetIds2Networks.containsKey(vip.networkId())) {
-					
-					// get the network object that the vip is on
-					Network network = relevantNetIds2Networks.get(vip.networkId());
-					
-					logger.info("SwarmDiscoveryUtil["+this.context+"] Found qualifying docker service["+service.spec().name()+"] "
-							+ "on network: " + network.name() +"["+ network.id() + ":" +vip.addr() +"]");
+					// does the service have a VIP on one of the networks we care about?
+					if (relevantNetIds2Networks.containsKey(vip.networkId())) {
 
-					// if so, then lets find all its tasks (actual container instances of the service)
-					List<Task> tasks = docker.listTasks(Task.Criteria.builder().serviceName(service.spec().name()).build());
+						// get the network object that the vip is on
+						Network network = relevantNetIds2Networks.get(vip.networkId());
 
-					if (tasks == null) {
-						logger.warning("SwarmDiscoveryUtil["+this.context+"] docker.listTasks() returned NULL for service:" + service.spec().name() + ", skipping this service");
-						continue;
-					}
-					
-					// for every task, lets get its network attachments
-					for (Task task : tasks) {
-						
-						ImmutableList<NetworkAttachment> networkAttachments = task.networkAttachments();
-						if (networkAttachments == null) {
-							logger.warning("SwarmDiscoveryUtil["+this.context+"] task.networkAttachments() returned NULL for task "
-									+ "id:" + task.id() + 
-									" name:" + task.name() + 
-									" nodeid:" + task.nodeId() + 
-									" I am skipping this task for service: " + service.spec().name());
+						logger.info("SwarmDiscoveryUtil[" + this.context + "] Found qualifying docker service[" + service.spec().name() + "] "
+								+ "on network: " + network.name() + "[" + network.id() + ":" + vip.addr() + "]");
+
+						// if so, then lets find all its tasks (actual container instances of the service)
+						List<Task> tasks = docker.listTasks(Task.Criteria.builder().serviceName(service.spec().name()).build());
+
+						if (tasks == null) {
+							logger.warning("SwarmDiscoveryUtil[" + this.context + "] docker.listTasks() returned NULL for service:" + service.spec().name() + ", skipping this service");
 							continue;
 						}
-						
-						for (NetworkAttachment networkAttachment : networkAttachments) {
 
-							// if the network ID the task is = the current network we care about for 
-							// the service.. then lets treat it as a "discovered container"
-							// that we actually care about
-							if (networkAttachment.network().id().equals(vip.networkId())) {
-								boolean foundSelfService = isSelf(networkAttachment);
-								if(foundSelfService){
-								  logger.info("SwarmDiscoveryUtil["+this.context+"] Found own task, adding regardless of state.");
-								}
-								// if container is in status 'running', then add it!									
-								if (TaskStatus.TASK_STATE_RUNNING.equals(task.status().state()) || foundSelfService) {
-								
-									logger.info("SwarmDiscoveryUtil["+this.context+"] Found qualifying docker service task[taskId: " +task.id() + ", container: "+task.status().containerStatus().containerId()+ ", state: " + task.status().state()+ "] "
-											+ "on network: " + network.name() +"["+ network.id() + ":" + networkAttachment.addresses().iterator().next() +"]");																
-								
-									discoveredContainers.add(new DiscoveredContainer(network, service, task, networkAttachment));
+						// for every task, lets get its network attachments
+						for (Task task : tasks) {
+
+							ImmutableList<NetworkAttachment> networkAttachments = task.networkAttachments();
+							if (networkAttachments == null) {
+								logger.warning("SwarmDiscoveryUtil[" + this.context + "] task.networkAttachments() returned NULL for task "
+										+ "id:" + task.id() +
+										" name:" + task.name() +
+										" nodeid:" + task.nodeId() +
+										" I am skipping this task for service: " + service.spec().name());
+								continue;
+							}
+
+							for (NetworkAttachment networkAttachment : networkAttachments) {
+
+								// if the network ID the task is = the current network we care about for
+								// the service.. then lets treat it as a "discovered container"
+								// that we actually care about
+								if (networkAttachment.network().id().equals(vip.networkId())) {
+									boolean foundSelfService = isSelf(networkAttachment);
+									if (foundSelfService) {
+										logger.info("SwarmDiscoveryUtil[" + this.context + "] Found own task, adding regardless of state.");
+									}
+									// if container is in status 'running', then add it!
+									if (TaskStatus.TASK_STATE_RUNNING.equals(task.status().state()) || foundSelfService) {
+
+										logger.info("SwarmDiscoveryUtil[" + this.context + "] Found qualifying docker service task[taskId: " + task.id() + ", container: " + task.status().containerStatus().containerId() + ", state: " + task.status().state() + "] "
+												+ "on network: " + network.name() + "[" + network.id() + ":" + networkAttachment.addresses().iterator().next() + "]");
+
+										discoveredContainers.add(new DiscoveredContainer(network, service, task, networkAttachment));
+									}
 								}
 							}
 						}
@@ -511,7 +537,6 @@ public class SwarmDiscoveryUtil {
 				}
 			}
 		}
-
 		logger.info("SwarmDiscoveryUtil["+this.context+"] Returning set of discovered containers with size=" + discoveredContainers.size());
 		return discoveredContainers;
 	}

--- a/src/main/java/org/bitsofinfo/hazelcast/discovery/docker/swarm/filter/AbstractServiceFilter.java
+++ b/src/main/java/org/bitsofinfo/hazelcast/discovery/docker/swarm/filter/AbstractServiceFilter.java
@@ -1,0 +1,19 @@
+package org.bitsofinfo.hazelcast.discovery.docker.swarm.filter;
+
+import com.spotify.docker.client.messages.swarm.Service;
+
+/**
+ * Abstract filter, providing a concrete implementation of reject() base on negation of accept()
+ */
+public abstract class AbstractServiceFilter implements ServiceFilter{
+
+    /**
+     * @see ServiceFilter#reject(Service)
+     * @param service Service returned from criteria-based /services request
+     * @return
+     */
+    @Override
+    public boolean reject(Service service) {
+        return !accept(service);
+    }
+}

--- a/src/main/java/org/bitsofinfo/hazelcast/discovery/docker/swarm/filter/NameBasedServiceFilter.java
+++ b/src/main/java/org/bitsofinfo/hazelcast/discovery/docker/swarm/filter/NameBasedServiceFilter.java
@@ -14,7 +14,12 @@ public class NameBasedServiceFilter extends AbstractServiceFilter {
      */
     @Override
     public boolean accept(Service service) {
-        return serviceName.equals(service.spec().name());
+        try {
+            return serviceName.equals(service.spec().name());
+        }
+        catch (NullPointerException e) {
+            return false;
+        }
     }
 
     /**

--- a/src/main/java/org/bitsofinfo/hazelcast/discovery/docker/swarm/filter/NameBasedServiceFilter.java
+++ b/src/main/java/org/bitsofinfo/hazelcast/discovery/docker/swarm/filter/NameBasedServiceFilter.java
@@ -1,0 +1,27 @@
+package org.bitsofinfo.hazelcast.discovery.docker.swarm.filter;
+
+import com.spotify.docker.client.messages.swarm.Service;
+
+public class NameBasedServiceFilter extends AbstractServiceFilter {
+    private String serviceName;
+
+    public NameBasedServiceFilter(String serviceName) {
+        this.serviceName = serviceName;
+    }
+
+    /**
+     * @see ServiceFilter#accept(Service)
+     */
+    @Override
+    public boolean accept(Service service) {
+        return serviceName.equals(service.spec().name());
+    }
+
+    /**
+     * @see Object#toString()
+     */
+    @Override
+    public String toString() {
+        return "ServiceNameFilter: \"" + serviceName + "\".equals(service.spec().name())";
+    }
+}

--- a/src/main/java/org/bitsofinfo/hazelcast/discovery/docker/swarm/filter/NullServiceFilter.java
+++ b/src/main/java/org/bitsofinfo/hazelcast/discovery/docker/swarm/filter/NullServiceFilter.java
@@ -38,6 +38,6 @@ public class NullServiceFilter extends AbstractServiceFilter {
      */
     @Override
     public String toString() {
-        return "NullServiceFilter";
+        return getClass().getSimpleName();
     }
 }

--- a/src/main/java/org/bitsofinfo/hazelcast/discovery/docker/swarm/filter/NullServiceFilter.java
+++ b/src/main/java/org/bitsofinfo/hazelcast/discovery/docker/swarm/filter/NullServiceFilter.java
@@ -1,0 +1,43 @@
+package org.bitsofinfo.hazelcast.discovery.docker.swarm.filter;
+
+import com.spotify.docker.client.messages.swarm.Service;
+
+/**
+ * A concrete implementation of ServiceFilter which accepts all given Service instances, rejecting none.
+ */
+public class NullServiceFilter extends AbstractServiceFilter {
+
+    /**
+     * static instance for use, to avid instantiation overheads
+     */
+    private static final ServiceFilter instance = new NullServiceFilter();
+
+    /**
+     * private no-arg constructor to preclude unwarranted instantiation
+     */
+    private NullServiceFilter() {
+    }
+
+    /**
+     * @return static singleton instance
+     */
+    public static ServiceFilter getInstance() {
+        return instance;
+    }
+
+    /**
+     * @see ServiceFilter#accept(Service)
+     */
+    @Override
+    public boolean accept(Service service) {
+        return true;
+    }
+
+    /**
+     * @see Object#toString()
+     */
+    @Override
+    public String toString() {
+        return "NullServiceFilter";
+    }
+}

--- a/src/main/java/org/bitsofinfo/hazelcast/discovery/docker/swarm/filter/ServiceFilter.java
+++ b/src/main/java/org/bitsofinfo/hazelcast/discovery/docker/swarm/filter/ServiceFilter.java
@@ -1,0 +1,24 @@
+package org.bitsofinfo.hazelcast.discovery.docker.swarm.filter;
+
+import com.spotify.docker.client.messages.swarm.Service;
+
+/**
+ * A filter which determines whether a Service returned from a criteria-based /services request should actually be considered as a potential location of cluster peers
+ */
+
+public interface ServiceFilter {
+    /**
+     * Apply criteria and return true if this service meets the criteria.
+     * @param service Service returned from criteria-based /services request
+     * @return true if this Service meets additional criteria necessary for consideration
+     */
+    boolean accept(Service service);
+
+    /**
+     * Apply criteria and return false if this service meets the criteria.
+     * This method exists so that tests for rejection can be expressed without inline negation which would result in a Sonar violation.
+     * @param service Service returned from criteria-based /services request
+     * @return true if this Service does not meet additional criteria necessary for consideration
+     */
+    boolean reject(Service service);
+}

--- a/src/main/java/org/bitsofinfo/hazelcast/discovery/docker/swarm/filter/ServiceFilter.java
+++ b/src/main/java/org/bitsofinfo/hazelcast/discovery/docker/swarm/filter/ServiceFilter.java
@@ -16,7 +16,7 @@ public interface ServiceFilter {
 
     /**
      * Apply criteria and return false if this service meets the criteria.
-     * This method exists so that tests for rejection can be expressed without inline negation which would result in a Sonar violation.
+     * This method exists so that tests for rejection can be expressed without inline negation.
      * @param service Service returned from criteria-based /services request
      * @return true if this Service does not meet additional criteria necessary for consideration
      */

--- a/src/main/resources/hazelcast-docker-swarm-discovery-spi-example-address-picker.xml
+++ b/src/main/resources/hazelcast-docker-swarm-discovery-spi-example-address-picker.xml
@@ -58,14 +58,17 @@
                   	   -->
                   	  <property name="log-all-service-names-on-failed-discovery">${logAllServiceNamesOnFailedDiscovery}</property>
 
-                      <!-- The raw port that hazelcast is listening on 
-                        
-                           IMPORTANT: this is NOT a docker "published" port, nor is it necessarily
-                           a EXPOSEd port... it is simply the hazelcast port that the service
-                           is configured with, this must be the same for all matched containers
-                           in order to work, and just using the default of 5701 is the simplist
-                           way to go.
-                       -->
+                       <!-- 1.0-RC14+ ONLY: If enabled, perform strict "equals" name check of services returned from Docker -->
+                       <property name="strict-docker-service-name-comparison">${strictDockerServiceNameComparison}</property>
+
+                       <!-- The raw port that hazelcast is listening on
+
+                              IMPORTANT: this is NOT a docker "published" port, nor is it necessarily
+                              a EXPOSEd port... it is simply the hazelcast port that the service
+                              is configured with, this must be the same for all matched containers
+                              in order to work, and just using the default of 5701 is the simplist
+                              way to go.
+                          -->
                       <property name="hazelcast-peer-port">${hazelcastPeerPort}</property>      
                  </properties>
                  

--- a/src/main/resources/hazelcast-docker-swarm-discovery-spi-example-member-address-provider.xml
+++ b/src/main/resources/hazelcast-docker-swarm-discovery-spi-example-member-address-provider.xml
@@ -47,6 +47,7 @@
 	                <property name="swarmMgrUri">...</property>
 	                <property name="skipVerifySsl">true|false</property>
 	                <property name="logAllServiceNamesOnFailedDiscovery">true|false</property>
+	                <property name="strictDockerServiceNameComparison">true|false</property>
                 </properties>
         		 -->
         		


### PR DESCRIPTION
Define ServiceFilter package, interface and hierarchy
Use ServiceFilter to constrain explicitly on dockerServiceName the results from criteria-based /services request
Reduce level of some log outputs from INFO to FINE