### PR TITLE
codeformat

### DIFF
--- a/src/main/java/org/bitsofinfo/hazelcast/discovery/docker/swarm/DiscoveredContainer.java
+++ b/src/main/java/org/bitsofinfo/hazelcast/discovery/docker/swarm/DiscoveredContainer.java
@@ -8,73 +8,73 @@ import com.spotify.docker.client.messages.swarm.Task;
 /**
  * Contains information about a discovered container 
  * within a docker swarm service that is on a particular network
- * 
+ *
  * The Container's VIP on the related network is it's unique id
- * 
+ *
  * @author bitsofinfo
  *
  */
 public class DiscoveredContainer {
-	
+
 	private Network network;
 	private Service service;
 	private Task task;
 	private NetworkAttachment relevantNetworkAttachment;
-	
+
 	public DiscoveredContainer(Network network, Service service, Task task, NetworkAttachment relevantNetworkAttachment) {
 		this.network = network;
 		this.service = service;
 		this.task = task;
 		this.relevantNetworkAttachment = relevantNetworkAttachment;
 	}
-	
+
 	public String getIp() {
 		// return the first address, should only be one"x.x.x.x/mask"
 		return relevantNetworkAttachment.addresses().iterator().next().split("/")[0];
 	}
-	
+
 	public String getNetworkName() {
 		return network.name();
 	}
-	
+
 	public String getNetworkId() {
 		return network.id();
 	}
-	
+
 	public String getServiceName() {
 		return service.spec().name();
 	}
-	
+
 	public String getServiceId() {
 		return service.id();
 	}
-	
+
 	public String getContainerId() {
 		return task.status().containerStatus().containerId();
 	}
-	
+
 	public String getContainerImage() {
 		return task.spec().containerSpec().image();
 	}
-	
+
 	@Override
 	public int hashCode() {
 		return this.getIp().hashCode();
 	}
-	
+
 	@Override
 	public boolean equals(Object o) {
 		if (o instanceof DiscoveredContainer) {
 			return ((DiscoveredContainer)o).hashCode() == this.hashCode();
 		}
-		
+
 		return false;
 	}
-	
-	@Override 
+
+	@Override
 	public String toString() {
 		return this.getIp() + " : " + this.getContainerId();
 	}
-	
+
 
 }

--- a/src/main/java/org/bitsofinfo/hazelcast/discovery/docker/swarm/DockerSwarmDiscoveryConfiguration.java
+++ b/src/main/java/org/bitsofinfo/hazelcast/discovery/docker/swarm/DockerSwarmDiscoveryConfiguration.java
@@ -29,15 +29,15 @@ public class DockerSwarmDiscoveryConfiguration {
 	// port that is reachable by any other container on the same overlay network
 	public static final PropertyDefinition HAZELCAST_PEER_PORT =
 			new SimplePropertyDefinition("hazelcast-peer-port", true, PropertyTypeConverter.INTEGER);
-	
+
 	// Swarm MGR URI, overrides DOCKER_HOST
 	public static final PropertyDefinition SWARM_MGR_URI =
 			new SimplePropertyDefinition("swarm-mgr-uri", true, PropertyTypeConverter.STRING);
-	
+
 	// Skip Verify SSL
 	public static final PropertyDefinition SKIP_VERIFY_SSL =
 			new SimplePropertyDefinition("skip-verify-ssl", true, PropertyTypeConverter.BOOLEAN);
-	
+
 	// Log all service names on failed discovery
 	public static final PropertyDefinition LOG_ALL_SERVICE_NAMES_ON_FAILED_DISCOVERY =
 			new SimplePropertyDefinition("log-all-service-names-on-failed-discovery", true, PropertyTypeConverter.BOOLEAN);

--- a/src/main/java/org/bitsofinfo/hazelcast/discovery/docker/swarm/DockerSwarmDiscoveryStrategy.java
+++ b/src/main/java/org/bitsofinfo/hazelcast/discovery/docker/swarm/DockerSwarmDiscoveryStrategy.java
@@ -1,17 +1,17 @@
 package org.bitsofinfo.hazelcast.discovery.docker.swarm;
 
+import com.hazelcast.logging.ILogger;
+import com.hazelcast.nio.Address;
+import com.hazelcast.spi.discovery.AbstractDiscoveryStrategy;
+import com.hazelcast.spi.discovery.DiscoveryNode;
+import com.hazelcast.spi.discovery.SimpleDiscoveryNode;
+
 import java.net.URI;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
-
-import com.hazelcast.logging.ILogger;
-import com.hazelcast.nio.Address;
-import com.hazelcast.spi.discovery.AbstractDiscoveryStrategy;
-import com.hazelcast.spi.discovery.DiscoveryNode;
-import com.hazelcast.spi.discovery.SimpleDiscoveryNode;
 
 /**
  * DiscoveryStrategy for Docker Swarm

--- a/src/main/java/org/bitsofinfo/hazelcast/discovery/docker/swarm/DockerSwarmDiscoveryStrategy.java
+++ b/src/main/java/org/bitsofinfo/hazelcast/discovery/docker/swarm/DockerSwarmDiscoveryStrategy.java
@@ -15,10 +15,10 @@ import com.hazelcast.spi.discovery.SimpleDiscoveryNode;
 
 /**
  * DiscoveryStrategy for Docker Swarm
- * 
+ *
  * You must have a system ENVIRONMENT variable defined
  * for DOCKER_HOST for this to work
- * 
+ *
  * @author bitsofinfo
  *
  */
@@ -28,7 +28,7 @@ public class DockerSwarmDiscoveryStrategy extends AbstractDiscoveryStrategy {
 
 	/**
 	 * Constructor
-	 * 
+	 *
 	 * @param localDiscoveryNode
 	 * @param logger
 	 * @param properties
@@ -47,31 +47,31 @@ public class DockerSwarmDiscoveryStrategy extends AbstractDiscoveryStrategy {
 		Boolean strictDockerServiceNameComparison = getOrDefault("strict-docker-service-name-comparison", DockerSwarmDiscoveryConfiguration.STRICT_DOCKER_SERVICE_NAME_COMPARISON, false);
 
 		try {
-			
+
 			URI swarmMgr = null;
 			if (swarmMgrUri == null && System.getenv("DOCKER_HOST") != null) {
 				swarmMgr = new URI(System.getenv("DOCKER_HOST"));
 			} else {
 				swarmMgr = new URI(swarmMgrUri);
 			}
-			
+
 			this.swarmDiscoveryUtil = new SwarmDiscoveryUtil( this.getClass().getSimpleName(),
-															 rawDockerNetworkNames,
-															 rawDockerServiceLabels,
-															 rawDockerServiceNames,
-															 hazelcastPeerPort,
-															 false, // dont bind channel, the AddressPicker does this
-															 swarmMgr,
-															 skipVerifySsl,
-															 logAllServiceNamesOnFailedDiscovery,
-															 strictDockerServiceNameComparison);
+					rawDockerNetworkNames,
+					rawDockerServiceLabels,
+					rawDockerServiceNames,
+					hazelcastPeerPort,
+					false, // dont bind channel, the AddressPicker does this
+					swarmMgr,
+					skipVerifySsl,
+					logAllServiceNamesOnFailedDiscovery,
+					strictDockerServiceNameComparison);
 		} catch(Exception e) {
 			String msg = "Unexpected error configuring SwarmDiscoveryUtil: " + e.getMessage();
 			logger.severe(msg,e);
 			throw new RuntimeException(msg,e);
 		}
 
-	}                              
+	}
 
 	@Override
 	public Iterable<DiscoveryNode> discoverNodes() {
@@ -81,17 +81,17 @@ public class DockerSwarmDiscoveryStrategy extends AbstractDiscoveryStrategy {
 		try {
 
 			Set<DiscoveredContainer> discoveredContainers = this.swarmDiscoveryUtil.discoverContainers();
-			
+
 			/**
 			 * We have all the containers, convert to DiscoveryNodes and return...
 			 */
-			getLogger().info("discoverNodes() DiscoveredContainers["+discoveredContainers.size()+"]: " + 
+			getLogger().info("discoverNodes() DiscoveredContainers["+discoveredContainers.size()+"]: " +
 					Arrays.toString(discoveredContainers.toArray(new DiscoveredContainer[]{})));
-			
+
 			for (DiscoveredContainer container : discoveredContainers) {
 				toReturn.add(new SimpleDiscoveryNode(
 						new Address(container.getIp(),
-									swarmDiscoveryUtil.getHazelcastPeerPort())));
+								swarmDiscoveryUtil.getHazelcastPeerPort())));
 			}
 
 			return toReturn;

--- a/src/main/java/org/bitsofinfo/hazelcast/discovery/docker/swarm/DockerSwarmDiscoveryStrategyFactory.java
+++ b/src/main/java/org/bitsofinfo/hazelcast/discovery/docker/swarm/DockerSwarmDiscoveryStrategyFactory.java
@@ -1,14 +1,14 @@
 package org.bitsofinfo.hazelcast.discovery.docker.swarm;
 
-import java.util.Arrays;
-import java.util.Collection;
-import java.util.Map;
-
 import com.hazelcast.config.properties.PropertyDefinition;
 import com.hazelcast.logging.ILogger;
 import com.hazelcast.spi.discovery.DiscoveryNode;
 import com.hazelcast.spi.discovery.DiscoveryStrategy;
 import com.hazelcast.spi.discovery.DiscoveryStrategyFactory;
+
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Map;
 
 public class DockerSwarmDiscoveryStrategyFactory implements DiscoveryStrategyFactory {
 

--- a/src/main/java/org/bitsofinfo/hazelcast/discovery/docker/swarm/DockerSwarmDiscoveryStrategyFactory.java
+++ b/src/main/java/org/bitsofinfo/hazelcast/discovery/docker/swarm/DockerSwarmDiscoveryStrategyFactory.java
@@ -14,14 +14,14 @@ public class DockerSwarmDiscoveryStrategyFactory implements DiscoveryStrategyFac
 
 	private static final Collection<PropertyDefinition> PROPERTIES =
 			Arrays.asList(new PropertyDefinition[]{
-						DockerSwarmDiscoveryConfiguration.DOCKER_SERVICE_LABELS,
-						DockerSwarmDiscoveryConfiguration.DOCKER_NETWORK_NAMES,
-						DockerSwarmDiscoveryConfiguration.DOCKER_SERVICE_NAMES,
-						DockerSwarmDiscoveryConfiguration.HAZELCAST_PEER_PORT,
-						DockerSwarmDiscoveryConfiguration.SWARM_MGR_URI,
-						DockerSwarmDiscoveryConfiguration.SKIP_VERIFY_SSL,
-						DockerSwarmDiscoveryConfiguration.LOG_ALL_SERVICE_NAMES_ON_FAILED_DISCOVERY
-					});
+					DockerSwarmDiscoveryConfiguration.DOCKER_SERVICE_LABELS,
+					DockerSwarmDiscoveryConfiguration.DOCKER_NETWORK_NAMES,
+					DockerSwarmDiscoveryConfiguration.DOCKER_SERVICE_NAMES,
+					DockerSwarmDiscoveryConfiguration.HAZELCAST_PEER_PORT,
+					DockerSwarmDiscoveryConfiguration.SWARM_MGR_URI,
+					DockerSwarmDiscoveryConfiguration.SKIP_VERIFY_SSL,
+					DockerSwarmDiscoveryConfiguration.LOG_ALL_SERVICE_NAMES_ON_FAILED_DISCOVERY
+			});
 
 	public Class<? extends DiscoveryStrategy> getDiscoveryStrategyType() {
 		// Returns the actual class type of the DiscoveryStrategy
@@ -37,7 +37,7 @@ public class DockerSwarmDiscoveryStrategyFactory implements DiscoveryStrategyFac
 												  ILogger logger,
 												  Map<String, Comparable> properties ) {
 
-		return new DockerSwarmDiscoveryStrategy( discoveryNode, logger, properties );                                      
-	}   
+		return new DockerSwarmDiscoveryStrategy( discoveryNode, logger, properties );
+	}
 
 }

--- a/src/main/java/org/bitsofinfo/hazelcast/discovery/docker/swarm/SkipVerifyDockerCertificatesStore.java
+++ b/src/main/java/org/bitsofinfo/hazelcast/discovery/docker/swarm/SkipVerifyDockerCertificatesStore.java
@@ -1,11 +1,11 @@
 package org.bitsofinfo.hazelcast.discovery.docker.swarm;
 
-import javax.net.ssl.HostnameVerifier;
+import com.spotify.docker.client.DockerCertificatesStore;
 import org.apache.http.conn.ssl.NoopHostnameVerifier;
 import org.apache.http.ssl.SSLContexts;
-import javax.net.ssl.SSLContext;
 
-import com.spotify.docker.client.DockerCertificatesStore;
+import javax.net.ssl.HostnameVerifier;
+import javax.net.ssl.SSLContext;
 
 public class SkipVerifyDockerCertificatesStore implements DockerCertificatesStore {
 

--- a/src/main/java/org/bitsofinfo/hazelcast/discovery/docker/swarm/SwarmAddressPicker.java
+++ b/src/main/java/org/bitsofinfo/hazelcast/discovery/docker/swarm/SwarmAddressPicker.java
@@ -1,11 +1,11 @@
 package org.bitsofinfo.hazelcast.discovery.docker.swarm;
 
-import java.net.URI;
-import java.nio.channels.ServerSocketChannel;
-
 import com.hazelcast.instance.AddressPicker;
 import com.hazelcast.logging.ILogger;
 import com.hazelcast.nio.Address;
+
+import java.net.URI;
+import java.nio.channels.ServerSocketChannel;
 
 /**
  * Custom AddressPicker that works for hazelcast instances running in swarm service instances

--- a/src/main/java/org/bitsofinfo/hazelcast/discovery/docker/swarm/SwarmAddressPicker.java
+++ b/src/main/java/org/bitsofinfo/hazelcast/discovery/docker/swarm/SwarmAddressPicker.java
@@ -33,7 +33,7 @@ import com.hazelcast.nio.Address;
  * @see <a href="https://github.com/hazelcast/hazelcast/issues/10801">Hazelcast GitHub Issue #10801</a>
  */
 public class SwarmAddressPicker implements AddressPicker {
-	
+
     public static final String PROP_DOCKER_NETWORK_NAMES = "dockerNetworkNames";
     public static final String PROP_DOCKER_SERVICE_LABELS = "dockerServiceLabels";
     public static final String PROP_DOCKER_SERVICE_NAMES = "dockerServiceNames";
@@ -47,37 +47,37 @@ public class SwarmAddressPicker implements AddressPicker {
      * Constructor
      */
 
-    
+
     public SwarmAddressPicker(final ILogger iLogger) {
         final String dockerNetworkNames = System.getProperty(PROP_DOCKER_NETWORK_NAMES);
         final String dockerServiceLabels = System.getProperty(PROP_DOCKER_SERVICE_LABELS);
         final String dockerServiceNames = System.getProperty(PROP_DOCKER_SERVICE_NAMES);
         final Integer hazelcastPeerPort = Integer.valueOf(System.getProperty(PROP_HAZELCAST_PEER_PORT));
-       
-       String swarmMgrUri = System.getProperty(PROP_SWARM_MGR_URI);
+
+        String swarmMgrUri = System.getProperty(PROP_SWARM_MGR_URI);
         if (swarmMgrUri == null || swarmMgrUri.trim().isEmpty()) {
-        		swarmMgrUri = System.getenv("DOCKER_HOST");
+            swarmMgrUri = System.getenv("DOCKER_HOST");
         }
-        
+
         Boolean skipVerifySsl = false;
         if (System.getProperty(PROP_SKIP_VERIFY_SSL) != null) {
-        		skipVerifySsl = Boolean.valueOf(System.getProperty(PROP_SKIP_VERIFY_SSL));
+            skipVerifySsl = Boolean.valueOf(System.getProperty(PROP_SKIP_VERIFY_SSL));
         }
 
         initialize(iLogger, dockerNetworkNames, dockerServiceLabels, dockerServiceNames, hazelcastPeerPort, swarmMgrUri, skipVerifySsl);
     }
 
     public SwarmAddressPicker(final ILogger iLogger, final String dockerNetworkNames, final String dockerServiceLabels,
-        final String dockerServiceNames, final Integer hazelcastPeerPort) {
+                              final String dockerServiceNames, final Integer hazelcastPeerPort) {
 
-    		String swarmMgrUri = System.getenv("DOCKER_HOST"); 
-    		Boolean skipVerifySsl = false;
-    		
+        String swarmMgrUri = System.getenv("DOCKER_HOST");
+        Boolean skipVerifySsl = false;
+
         initialize(iLogger, dockerNetworkNames, dockerServiceLabels, dockerServiceNames, hazelcastPeerPort, swarmMgrUri, skipVerifySsl);
     }
 
     private void initialize(final ILogger iLogger, final String dockerNetworkNames, final String dockerServiceLabels,
-        final String dockerServiceNames, final Integer hazelcastPeerPort, final String swarmMgrUri, final Boolean skipVerifySsl) {
+                            final String dockerServiceNames, final Integer hazelcastPeerPort, final String swarmMgrUri, final Boolean skipVerifySsl) {
 
         final int port;
 
@@ -91,25 +91,25 @@ public class SwarmAddressPicker implements AddressPicker {
         try {
             URI swarmMgr = null;
             if (swarmMgrUri == null || swarmMgrUri.trim().isEmpty()) {
-            		swarmMgr = new URI(System.getenv("DOCKER_HOST")); 
+                swarmMgr = new URI(System.getenv("DOCKER_HOST"));
             }
-            
+
             this.swarmDiscoveryUtil = new SwarmDiscoveryUtil(
-                this.getClass().getSimpleName(),
-                dockerNetworkNames,
-                dockerServiceLabels,
-                dockerServiceNames,
-                port,
-                true,
-                swarmMgr,
-                skipVerifySsl,
-                false,
-                false
+                    this.getClass().getSimpleName(),
+                    dockerNetworkNames,
+                    dockerServiceLabels,
+                    dockerServiceNames,
+                    port,
+                    true,
+                    swarmMgr,
+                    skipVerifySsl,
+                    false,
+                    false
             );
         } catch (final Exception e) {
             throw new RuntimeException(
-                "SwarmAddressPicker: Error constructing SwarmDiscoveryUtil: " + e.getMessage(),
-                e
+                    "SwarmAddressPicker: Error constructing SwarmDiscoveryUtil: " + e.getMessage(),
+                    e
             );
         }
     }

--- a/src/main/java/org/bitsofinfo/hazelcast/discovery/docker/swarm/SwarmDiscoveryUtil.java
+++ b/src/main/java/org/bitsofinfo/hazelcast/discovery/docker/swarm/SwarmDiscoveryUtil.java
@@ -1,29 +1,12 @@
 package org.bitsofinfo.hazelcast.discovery.docker.swarm;
 
-import java.net.InetAddress;
-import java.net.InetSocketAddress;
-import java.net.NetworkInterface;
-import java.net.ServerSocket;
-import java.net.URI;
-import java.nio.channels.ServerSocketChannel;
-import java.util.Enumeration;
-import java.util.HashMap;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Map;
-import java.util.Set;
-import java.util.TreeMap;
-import java.util.TreeSet;
-import java.util.concurrent.TimeUnit;
-
-
 import com.hazelcast.core.HazelcastException;
 import com.hazelcast.logging.ILogger;
 import com.hazelcast.logging.Logger;
 import com.hazelcast.nio.Address;
 import com.spotify.docker.client.DefaultDockerClient;
-import com.spotify.docker.client.DockerClient;
 import com.spotify.docker.client.DefaultDockerClient.Builder;
+import com.spotify.docker.client.DockerClient;
 import com.spotify.docker.client.DockerClient.ListNetworksParam;
 import com.spotify.docker.client.messages.Network;
 import com.spotify.docker.client.messages.swarm.EndpointVirtualIp;
@@ -37,7 +20,22 @@ import org.bitsofinfo.hazelcast.discovery.docker.swarm.filter.NameBasedServiceFi
 import org.bitsofinfo.hazelcast.discovery.docker.swarm.filter.NullServiceFilter;
 import org.bitsofinfo.hazelcast.discovery.docker.swarm.filter.ServiceFilter;
 
+import java.net.InetAddress;
+import java.net.InetSocketAddress;
+import java.net.NetworkInterface;
+import java.net.ServerSocket;
 import java.net.SocketException;
+import java.net.URI;
+import java.nio.channels.ServerSocketChannel;
+import java.util.Enumeration;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.TreeMap;
+import java.util.TreeSet;
+import java.util.concurrent.TimeUnit;
 
 /**
  * SwarmDiscoveryUtil is the workhorse of this discovery SPI implementation

--- a/src/main/java/org/bitsofinfo/hazelcast/discovery/docker/swarm/SwarmDiscoveryUtil.java
+++ b/src/main/java/org/bitsofinfo/hazelcast/discovery/docker/swarm/SwarmDiscoveryUtil.java
@@ -41,9 +41,9 @@ import java.net.SocketException;
 
 /**
  * SwarmDiscoveryUtil is the workhorse of this discovery SPI implementation
- * 
- * 
- * 
+ *
+ *
+ *
  * @author bitsofinfo
  *
  */
@@ -445,7 +445,7 @@ public class SwarmDiscoveryUtil {
 	/**
 	 * Discover containers on the relevant networks that match the given
 	 * service criteria and service filter
-	 * 
+	 *
 	 * @param docker
 	 * @param relevantNetIds2Networks
 	 * @param criteria to be passed as a parameter to the /services request
@@ -453,10 +453,10 @@ public class SwarmDiscoveryUtil {
 	 * @return set of DiscoveredContainer instances
 	 * @throws Exception
 	 */
-	private Set<DiscoveredContainer> discoverContainersViaCriteria(DockerClient docker, 
-			Map<String,Network> relevantNetIds2Networks, 
-			Service.Criteria criteria,
-			ServiceFilter serviceFilter) throws Exception {
+	private Set<DiscoveredContainer> discoverContainersViaCriteria(DockerClient docker,
+																   Map<String,Network> relevantNetIds2Networks,
+																   Service.Criteria criteria,
+																   ServiceFilter serviceFilter) throws Exception {
 
 		Set<DiscoveredContainer> discoveredContainers = new HashSet<DiscoveredContainer>();
 

--- a/src/main/java/org/bitsofinfo/hazelcast/discovery/docker/swarm/SwarmMemberAddressProvider.java
+++ b/src/main/java/org/bitsofinfo/hazelcast/discovery/docker/swarm/SwarmMemberAddressProvider.java
@@ -39,127 +39,127 @@ import com.hazelcast.spi.MemberAddressProvider;
  * @see https://github.com/hazelcast/hazelcast/pull/11548
  */
 public class SwarmMemberAddressProvider implements MemberAddressProvider {
-	
-    private static final String PROP_DOCKER_NETWORK_NAMES = "dockerNetworkNames";
-    private static final String PROP_DOCKER_SERVICE_LABELS = "dockerServiceLabels";
-    private static final String PROP_DOCKER_SERVICE_NAMES = "dockerServiceNames";
-    private static final String PROP_HAZELCAST_PEER_PORT = "hazelcastPeerPort";
 
-    public static final String PROP_SWARM_MGR_URI = "swarmMgrUri";
-    public static final String PROP_SKIP_VERIFY_SSL = "skipVerifySsl";
-    
-    public static final String PROP_LOG_ALL_SERVICE_NAMES_ON_FAILED_DISCOVERY = "logAllServiceNamesOnFailedDiscovery";
-    public static final String PROP_STRICT_DOCKER_SERVICE_NAME_COMPARISON = "strictDockerServiceNameComparison";
+	private static final String PROP_DOCKER_NETWORK_NAMES = "dockerNetworkNames";
+	private static final String PROP_DOCKER_SERVICE_LABELS = "dockerServiceLabels";
+	private static final String PROP_DOCKER_SERVICE_NAMES = "dockerServiceNames";
+	private static final String PROP_HAZELCAST_PEER_PORT = "hazelcastPeerPort";
 
-    private SwarmDiscoveryUtil swarmDiscoveryUtil = null;
-    
-    private ILogger logger = Logger.getLogger(SwarmMemberAddressProvider.class);
+	public static final String PROP_SWARM_MGR_URI = "swarmMgrUri";
+	public static final String PROP_SKIP_VERIFY_SSL = "skipVerifySsl";
 
-    /**
-     * Constructor
-     */
-    public SwarmMemberAddressProvider() {
-    	
-    		final String dockerNetworkNames = System.getProperty(PROP_DOCKER_NETWORK_NAMES);
-        final String dockerServiceLabels = System.getProperty(PROP_DOCKER_SERVICE_LABELS);
-        final String dockerServiceNames = System.getProperty(PROP_DOCKER_SERVICE_NAMES);
-        final Integer hazelcastPeerPort = Integer.valueOf(System.getProperty(PROP_HAZELCAST_PEER_PORT));
-       
-       String swarmMgrUri = System.getProperty(PROP_SWARM_MGR_URI);
-        if (swarmMgrUri == null || swarmMgrUri.trim().isEmpty()) {
-        		swarmMgrUri = System.getenv("DOCKER_HOST");
-        }
-        
-        Boolean skipVerifySsl = false;
-        if (System.getProperty(PROP_SKIP_VERIFY_SSL) != null) {
-        		skipVerifySsl = Boolean.valueOf(System.getProperty(PROP_SKIP_VERIFY_SSL));
-        }
-        
-        Boolean logAllServiceNamesOnFailedDiscovery = false;
-        if (System.getProperty(PROP_LOG_ALL_SERVICE_NAMES_ON_FAILED_DISCOVERY) != null) {
-        		logAllServiceNamesOnFailedDiscovery = Boolean.valueOf(System.getProperty(PROP_LOG_ALL_SERVICE_NAMES_ON_FAILED_DISCOVERY));
-        }
+	public static final String PROP_LOG_ALL_SERVICE_NAMES_ON_FAILED_DISCOVERY = "logAllServiceNamesOnFailedDiscovery";
+	public static final String PROP_STRICT_DOCKER_SERVICE_NAME_COMPARISON = "strictDockerServiceNameComparison";
+
+	private SwarmDiscoveryUtil swarmDiscoveryUtil = null;
+
+	private ILogger logger = Logger.getLogger(SwarmMemberAddressProvider.class);
+
+	/**
+	 * Constructor
+	 */
+	public SwarmMemberAddressProvider() {
+
+		final String dockerNetworkNames = System.getProperty(PROP_DOCKER_NETWORK_NAMES);
+		final String dockerServiceLabels = System.getProperty(PROP_DOCKER_SERVICE_LABELS);
+		final String dockerServiceNames = System.getProperty(PROP_DOCKER_SERVICE_NAMES);
+		final Integer hazelcastPeerPort = Integer.valueOf(System.getProperty(PROP_HAZELCAST_PEER_PORT));
+
+		String swarmMgrUri = System.getProperty(PROP_SWARM_MGR_URI);
+		if (swarmMgrUri == null || swarmMgrUri.trim().isEmpty()) {
+			swarmMgrUri = System.getenv("DOCKER_HOST");
+		}
+
+		Boolean skipVerifySsl = false;
+		if (System.getProperty(PROP_SKIP_VERIFY_SSL) != null) {
+			skipVerifySsl = Boolean.valueOf(System.getProperty(PROP_SKIP_VERIFY_SSL));
+		}
+
+		Boolean logAllServiceNamesOnFailedDiscovery = false;
+		if (System.getProperty(PROP_LOG_ALL_SERVICE_NAMES_ON_FAILED_DISCOVERY) != null) {
+			logAllServiceNamesOnFailedDiscovery = Boolean.valueOf(System.getProperty(PROP_LOG_ALL_SERVICE_NAMES_ON_FAILED_DISCOVERY));
+		}
 
 		Boolean strictDockerServiceNameComparison = false;
 		if (System.getProperty(PROP_STRICT_DOCKER_SERVICE_NAME_COMPARISON) != null) {
 			strictDockerServiceNameComparison = Boolean.valueOf(System.getProperty(PROP_STRICT_DOCKER_SERVICE_NAME_COMPARISON));
 		}
 
-        initialize(dockerNetworkNames, dockerServiceLabels, dockerServiceNames, hazelcastPeerPort, 
-        		swarmMgrUri, skipVerifySsl, logAllServiceNamesOnFailedDiscovery, strictDockerServiceNameComparison);
-    }
-    
+		initialize(dockerNetworkNames, dockerServiceLabels, dockerServiceNames, hazelcastPeerPort,
+				swarmMgrUri, skipVerifySsl, logAllServiceNamesOnFailedDiscovery, strictDockerServiceNameComparison);
+	}
 
-    public SwarmMemberAddressProvider(final String dockerNetworkNames, final String dockerServiceLabels,
-        final String dockerServiceNames, final Integer hazelcastPeerPort, final Boolean logAllServiceNamesOnFailedDiscovery,
+
+	public SwarmMemberAddressProvider(final String dockerNetworkNames, final String dockerServiceLabels,
+									  final String dockerServiceNames, final Integer hazelcastPeerPort, final Boolean logAllServiceNamesOnFailedDiscovery,
 									  final Boolean strictDockerServiceNameComparison) {
 
-    		String swarmMgrUri = System.getenv("DOCKER_HOST"); 
+		String swarmMgrUri = System.getenv("DOCKER_HOST");
 		Boolean skipVerifySsl = false;
-		
-		initialize(dockerNetworkNames, dockerServiceLabels, dockerServiceNames, hazelcastPeerPort, 
+
+		initialize(dockerNetworkNames, dockerServiceLabels, dockerServiceNames, hazelcastPeerPort,
 				swarmMgrUri, skipVerifySsl, logAllServiceNamesOnFailedDiscovery, strictDockerServiceNameComparison);
-    }
-    
-    /**
-     * If you do not provide any properties, the class may have either a 
-     * no-arg constructor or a constructor accepting a single java.util.Properties instance. 
-     * On the other hand, if you do provide properties in the configuration, 
-     * the class must have a constructor accepting a single java.util.Properties instance.
-     * 
-     * See: https://docs.hazelcast.org/docs/3.9.4/manual/html-single/index.html#member-address-provider-spi
-     * @param properties
-     */
-    public SwarmMemberAddressProvider(Properties properties) {
-    	
-    		String dockerNetworkNames = (String)properties.get(PROP_DOCKER_NETWORK_NAMES);
-    		if (dockerNetworkNames == null || dockerNetworkNames.trim().isEmpty()) {
-    			dockerNetworkNames = System.getProperty(PROP_DOCKER_NETWORK_NAMES);
-    		}
-    		
-    		String dockerServiceLabels = (String)properties.get(PROP_DOCKER_SERVICE_LABELS);
-    		if (dockerServiceLabels == null || dockerServiceLabels.trim().isEmpty()) {
-    			dockerServiceLabels = System.getProperty(PROP_DOCKER_SERVICE_LABELS);
-    		}
-    		
-    		String dockerServiceNames = (String)properties.get(PROP_DOCKER_SERVICE_NAMES);
-    		if (dockerServiceNames == null || dockerServiceNames.trim().isEmpty()) {
-    			dockerServiceNames = System.getProperty(PROP_DOCKER_SERVICE_NAMES);
-    		}
-    		
-    		
-    		Object rawHazelcastPeerPort = properties.get(PROP_HAZELCAST_PEER_PORT);
-    		if (rawHazelcastPeerPort == null || rawHazelcastPeerPort.toString().trim().isEmpty()) {
-    			rawHazelcastPeerPort = System.getProperty(PROP_HAZELCAST_PEER_PORT);
-    		}
-    		Integer hazelcastPeerPort = 5701;
-    		if (rawHazelcastPeerPort instanceof String) {
-    			try {
-    				hazelcastPeerPort = Integer.valueOf(rawHazelcastPeerPort.toString());
-    			} catch(Throwable ignore) {}
-    		} else if (rawHazelcastPeerPort instanceof Integer) {
-    			hazelcastPeerPort = (Integer)rawHazelcastPeerPort;
-    		}
-    		
-    		
-    		String swarmMgrUri = (String)properties.get(PROP_SWARM_MGR_URI);
-    		if (swarmMgrUri == null || swarmMgrUri.trim().isEmpty()) {
-    			swarmMgrUri = System.getProperty(PROP_SWARM_MGR_URI);
-    		}
-    		if (swarmMgrUri == null || swarmMgrUri.trim().isEmpty()) {
-        		swarmMgrUri = System.getenv("DOCKER_HOST");
-        }
-    		
-    		
-    		Object rawSkipVerifySsl = properties.get(PROP_SKIP_VERIFY_SSL);
-    		if (rawSkipVerifySsl == null || rawSkipVerifySsl.toString().trim().isEmpty()) {
-    			rawSkipVerifySsl = System.getProperty(PROP_SKIP_VERIFY_SSL);
-    		}
-    		Boolean skipVerifySsl = false;
-	    if (rawSkipVerifySsl != null) {
-	    		skipVerifySsl = Boolean.valueOf(rawSkipVerifySsl.toString());
-	    }
-	    
+	}
+
+	/**
+	 * If you do not provide any properties, the class may have either a
+	 * no-arg constructor or a constructor accepting a single java.util.Properties instance.
+	 * On the other hand, if you do provide properties in the configuration,
+	 * the class must have a constructor accepting a single java.util.Properties instance.
+	 *
+	 * See: https://docs.hazelcast.org/docs/3.9.4/manual/html-single/index.html#member-address-provider-spi
+	 * @param properties
+	 */
+	public SwarmMemberAddressProvider(Properties properties) {
+
+		String dockerNetworkNames = (String)properties.get(PROP_DOCKER_NETWORK_NAMES);
+		if (dockerNetworkNames == null || dockerNetworkNames.trim().isEmpty()) {
+			dockerNetworkNames = System.getProperty(PROP_DOCKER_NETWORK_NAMES);
+		}
+
+		String dockerServiceLabels = (String)properties.get(PROP_DOCKER_SERVICE_LABELS);
+		if (dockerServiceLabels == null || dockerServiceLabels.trim().isEmpty()) {
+			dockerServiceLabels = System.getProperty(PROP_DOCKER_SERVICE_LABELS);
+		}
+
+		String dockerServiceNames = (String)properties.get(PROP_DOCKER_SERVICE_NAMES);
+		if (dockerServiceNames == null || dockerServiceNames.trim().isEmpty()) {
+			dockerServiceNames = System.getProperty(PROP_DOCKER_SERVICE_NAMES);
+		}
+
+
+		Object rawHazelcastPeerPort = properties.get(PROP_HAZELCAST_PEER_PORT);
+		if (rawHazelcastPeerPort == null || rawHazelcastPeerPort.toString().trim().isEmpty()) {
+			rawHazelcastPeerPort = System.getProperty(PROP_HAZELCAST_PEER_PORT);
+		}
+		Integer hazelcastPeerPort = 5701;
+		if (rawHazelcastPeerPort instanceof String) {
+			try {
+				hazelcastPeerPort = Integer.valueOf(rawHazelcastPeerPort.toString());
+			} catch(Throwable ignore) {}
+		} else if (rawHazelcastPeerPort instanceof Integer) {
+			hazelcastPeerPort = (Integer)rawHazelcastPeerPort;
+		}
+
+
+		String swarmMgrUri = (String)properties.get(PROP_SWARM_MGR_URI);
+		if (swarmMgrUri == null || swarmMgrUri.trim().isEmpty()) {
+			swarmMgrUri = System.getProperty(PROP_SWARM_MGR_URI);
+		}
+		if (swarmMgrUri == null || swarmMgrUri.trim().isEmpty()) {
+			swarmMgrUri = System.getenv("DOCKER_HOST");
+		}
+
+
+		Object rawSkipVerifySsl = properties.get(PROP_SKIP_VERIFY_SSL);
+		if (rawSkipVerifySsl == null || rawSkipVerifySsl.toString().trim().isEmpty()) {
+			rawSkipVerifySsl = System.getProperty(PROP_SKIP_VERIFY_SSL);
+		}
+		Boolean skipVerifySsl = false;
+		if (rawSkipVerifySsl != null) {
+			skipVerifySsl = Boolean.valueOf(rawSkipVerifySsl.toString());
+		}
+
 
 		Object rawLogAllServiceNamesOnFailedDiscovery = properties.get(PROP_LOG_ALL_SERVICE_NAMES_ON_FAILED_DISCOVERY);
 		if (rawLogAllServiceNamesOnFailedDiscovery == null || rawLogAllServiceNamesOnFailedDiscovery.toString().trim().isEmpty()) {
@@ -180,54 +180,54 @@ public class SwarmMemberAddressProvider implements MemberAddressProvider {
 		}
 
 		initialize(dockerNetworkNames, dockerServiceLabels, dockerServiceNames, hazelcastPeerPort,
-    				swarmMgrUri, skipVerifySsl, logAllServiceNamesOnFailedDiscovery, strictDockerServiceNameComparison);
-    }
+				swarmMgrUri, skipVerifySsl, logAllServiceNamesOnFailedDiscovery, strictDockerServiceNameComparison);
+	}
 
-    public SwarmMemberAddressProvider(final String dockerNetworkNames, 
-    									 final String dockerServiceLabels,
-    									 final String dockerServiceNames, 
-    									 final Object hazelcastPeerPort,
-    									 final Object logAllServiceNamesOnFailedDiscovery,
-									     final Object strictDockerServiceNameComparison) {
+	public SwarmMemberAddressProvider(final String dockerNetworkNames,
+									  final String dockerServiceLabels,
+									  final String dockerServiceNames,
+									  final Object hazelcastPeerPort,
+									  final Object logAllServiceNamesOnFailedDiscovery,
+									  final Object strictDockerServiceNameComparison) {
 
-    		String swarmMgrUri = System.getenv("DOCKER_HOST"); 
+		String swarmMgrUri = System.getenv("DOCKER_HOST");
 		Boolean skipVerifySsl = false;
-		
-		initialize(dockerNetworkNames, dockerServiceLabels, dockerServiceNames, 
+
+		initialize(dockerNetworkNames, dockerServiceLabels, dockerServiceNames,
 				swarmMgrUri, skipVerifySsl, hazelcastPeerPort, logAllServiceNamesOnFailedDiscovery, strictDockerServiceNameComparison);
-    }
-    
-    private void initialize(final String dockerNetworkNames, final String dockerServiceLabels,
-            			final String dockerServiceNames, final Integer hazelcastPeerPort, 
-            			final String swarmMgrUri, final Boolean skipVerifySsl, final Boolean logAllServiceNamesOnFailedDiscovery,
+	}
+
+	private void initialize(final String dockerNetworkNames, final String dockerServiceLabels,
+							final String dockerServiceNames, final Integer hazelcastPeerPort,
+							final String swarmMgrUri, final Boolean skipVerifySsl, final Boolean logAllServiceNamesOnFailedDiscovery,
 							final Boolean strictDockerServiceNameComparison) {
-    	
-    		initialize(dockerNetworkNames,dockerServiceLabels,dockerServiceNames,
-    				swarmMgrUri,skipVerifySsl,hazelcastPeerPort,logAllServiceNamesOnFailedDiscovery, strictDockerServiceNameComparison);
-    }
+
+		initialize(dockerNetworkNames,dockerServiceLabels,dockerServiceNames,
+				swarmMgrUri,skipVerifySsl,hazelcastPeerPort,logAllServiceNamesOnFailedDiscovery, strictDockerServiceNameComparison);
+	}
 
 
-    private void initialize(final String dockerNetworkNames, 
-    						   final String dockerServiceLabels,
-    						   final String dockerServiceNames, 
-    						   final String swarmMgrUri, 
-    						   final Boolean skipVerifySsl, 
-    						   final Object rawHazelcastPeerPort,
-    						   final Object rawLogAllServiceNamesOnFailedDiscovery,
-							   final Object rawStrictDockerServiceNameComparison) {
-    	
-    		logger.info("SwarmMemberAddressProvider.initialize() passed properties: " + 
-    						"dockerNetworkNames:"+dockerNetworkNames + " " +
-    						"dockerServiceLabels:"+dockerServiceLabels + " " +
-    						"dockerServiceNames:"+dockerServiceNames + " " +
-    						"swarmMgrUri:"+swarmMgrUri + " " +
-    						"skipVerifySsl:"+skipVerifySsl + " " +
-    						"hazelcastPeerPort:"+rawHazelcastPeerPort + " " +
-    						"logAllServiceNamesOnFailedDiscovery:" + rawLogAllServiceNamesOnFailedDiscovery + " " +
-					        "strictDockerServiceNameComparison:" + rawStrictDockerServiceNameComparison
-    						);
+	private void initialize(final String dockerNetworkNames,
+							final String dockerServiceLabels,
+							final String dockerServiceNames,
+							final String swarmMgrUri,
+							final Boolean skipVerifySsl,
+							final Object rawHazelcastPeerPort,
+							final Object rawLogAllServiceNamesOnFailedDiscovery,
+							final Object rawStrictDockerServiceNameComparison) {
 
-    		Boolean logAllServiceNamesOnFailedDiscovery = false;
+		logger.info("SwarmMemberAddressProvider.initialize() passed properties: " +
+				"dockerNetworkNames:"+dockerNetworkNames + " " +
+				"dockerServiceLabels:"+dockerServiceLabels + " " +
+				"dockerServiceNames:"+dockerServiceNames + " " +
+				"swarmMgrUri:"+swarmMgrUri + " " +
+				"skipVerifySsl:"+skipVerifySsl + " " +
+				"hazelcastPeerPort:"+rawHazelcastPeerPort + " " +
+				"logAllServiceNamesOnFailedDiscovery:" + rawLogAllServiceNamesOnFailedDiscovery + " " +
+				"strictDockerServiceNameComparison:" + rawStrictDockerServiceNameComparison
+		);
+
+		Boolean logAllServiceNamesOnFailedDiscovery = false;
 		if (rawLogAllServiceNamesOnFailedDiscovery != null) {
 			if (rawLogAllServiceNamesOnFailedDiscovery instanceof String) {
 				try {
@@ -259,72 +259,72 @@ public class SwarmMemberAddressProvider implements MemberAddressProvider {
 				hazelcastPeerPort = (Integer)rawHazelcastPeerPort;
 			}
 		}
-    	
-        final int port;
 
-        if (hazelcastPeerPort != null) {
-            port = hazelcastPeerPort;
-        } else {
-            port = 5701;
-        }
+		final int port;
 
-        try {
-        	 	 URI swarmMgr = null;
-             if (swarmMgrUri == null || swarmMgrUri.trim().isEmpty()) {
-             	swarmMgr = new URI(System.getenv("DOCKER_HOST")); 
-             } else {
-            	 	swarmMgr = new URI(swarmMgrUri);
-             }
-             
-            this.swarmDiscoveryUtil = new SwarmDiscoveryUtil(
-            		this.getClass().getSimpleName(),
-                dockerNetworkNames,
-                dockerServiceLabels,
-                dockerServiceNames,
-                port,
-                
-                // do NOT bindSocketChannel
-                // this flag was originally here for SwarmAddressPicker, 
-                // see: https://github.com/hazelcast/hazelcast/issues/11997#issuecomment-354107373
-                false ,
-                
-                swarmMgr,
-                skipVerifySsl,
-                logAllServiceNamesOnFailedDiscovery,
+		if (hazelcastPeerPort != null) {
+			port = hazelcastPeerPort;
+		} else {
+			port = 5701;
+		}
+
+		try {
+			URI swarmMgr = null;
+			if (swarmMgrUri == null || swarmMgrUri.trim().isEmpty()) {
+				swarmMgr = new URI(System.getenv("DOCKER_HOST"));
+			} else {
+				swarmMgr = new URI(swarmMgrUri);
+			}
+
+			this.swarmDiscoveryUtil = new SwarmDiscoveryUtil(
+					this.getClass().getSimpleName(),
+					dockerNetworkNames,
+					dockerServiceLabels,
+					dockerServiceNames,
+					port,
+
+					// do NOT bindSocketChannel
+					// this flag was originally here for SwarmAddressPicker,
+					// see: https://github.com/hazelcast/hazelcast/issues/11997#issuecomment-354107373
+					false ,
+
+					swarmMgr,
+					skipVerifySsl,
+					logAllServiceNamesOnFailedDiscovery,
 					strictDockerServiceNameComparison
-            );
-        } catch (final Exception e) {
-            throw new RuntimeException(
-                "SwarmAddressPicker: Error constructing SwarmDiscoveryUtil: " + e.getMessage(),
-                e
-            );
-        }
-    }
+			);
+		} catch (final Exception e) {
+			throw new RuntimeException(
+					"SwarmAddressPicker: Error constructing SwarmDiscoveryUtil: " + e.getMessage(),
+					e
+			);
+		}
+	}
 
-    @Override
-    public InetSocketAddress getBindAddress() {
-        Address addr = this.swarmDiscoveryUtil.getMyAddress();
-        
-        if (addr == null) {
-	        logger.severe("SwarmMemberAddressProvider.getBindAddress(): "
-	        		+ "swarmDiscoveryUtil.getMyAddress() returned null Hazelcast "+Address.class.getName()+", I am returning null.");
-	        return null;
-        }
-        
-        return new InetSocketAddress(addr.getHost(), addr.getPort());
-    }
+	@Override
+	public InetSocketAddress getBindAddress() {
+		Address addr = this.swarmDiscoveryUtil.getMyAddress();
 
-    @Override
-    public InetSocketAddress getPublicAddress() {
-        Address addr = this.swarmDiscoveryUtil.getMyAddress();
-        
-        if (addr == null) {
-	        logger.severe("SwarmMemberAddressProvider.getPublicAddress(): "
-	        		+ "swarmDiscoveryUtil.getMyAddress() returned null Hazelcast "+Address.class.getName()+", I am returning null.");
-	        return null;
-        }
-        
-        return new InetSocketAddress(addr.getHost(), addr.getPort());
-    }
+		if (addr == null) {
+			logger.severe("SwarmMemberAddressProvider.getBindAddress(): "
+					+ "swarmDiscoveryUtil.getMyAddress() returned null Hazelcast "+Address.class.getName()+", I am returning null.");
+			return null;
+		}
+
+		return new InetSocketAddress(addr.getHost(), addr.getPort());
+	}
+
+	@Override
+	public InetSocketAddress getPublicAddress() {
+		Address addr = this.swarmDiscoveryUtil.getMyAddress();
+
+		if (addr == null) {
+			logger.severe("SwarmMemberAddressProvider.getPublicAddress(): "
+					+ "swarmDiscoveryUtil.getMyAddress() returned null Hazelcast "+Address.class.getName()+", I am returning null.");
+			return null;
+		}
+
+		return new InetSocketAddress(addr.getHost(), addr.getPort());
+	}
 
 }

--- a/src/main/java/org/bitsofinfo/hazelcast/discovery/docker/swarm/SwarmMemberAddressProvider.java
+++ b/src/main/java/org/bitsofinfo/hazelcast/discovery/docker/swarm/SwarmMemberAddressProvider.java
@@ -1,15 +1,13 @@
 package org.bitsofinfo.hazelcast.discovery.docker.swarm;
 
-import java.net.InetSocketAddress;
-import java.net.URI;
-import java.nio.channels.ServerSocketChannel;
-import java.util.Properties;
-
-import com.hazelcast.instance.AddressPicker;
 import com.hazelcast.logging.ILogger;
 import com.hazelcast.logging.Logger;
 import com.hazelcast.nio.Address;
 import com.hazelcast.spi.MemberAddressProvider;
+
+import java.net.InetSocketAddress;
+import java.net.URI;
+import java.util.Properties;
 
 /**
  * Custom MemberAddressProvider that works for hazelcast instances running in swarm service instances

--- a/src/main/java/org/bitsofinfo/hazelcast/discovery/docker/swarm/SystemPrintLogger.java
+++ b/src/main/java/org/bitsofinfo/hazelcast/discovery/docker/swarm/SystemPrintLogger.java
@@ -1,13 +1,12 @@
 package org.bitsofinfo.hazelcast.discovery.docker.swarm;
 
-import java.text.DateFormat;
-import java.text.SimpleDateFormat;
-import java.util.Date;
-import java.util.logging.Level;
-import java.util.logging.LogRecord;
-
 import com.hazelcast.logging.ILogger;
 import com.hazelcast.logging.LogEvent;
+
+import java.text.DateFormat;
+import java.text.SimpleDateFormat;
+import java.util.logging.Level;
+import java.util.logging.LogRecord;
 
 public class SystemPrintLogger implements ILogger {
 

--- a/src/main/java/org/bitsofinfo/hazelcast/discovery/docker/swarm/SystemPrintLogger.java
+++ b/src/main/java/org/bitsofinfo/hazelcast/discovery/docker/swarm/SystemPrintLogger.java
@@ -10,7 +10,7 @@ import com.hazelcast.logging.ILogger;
 import com.hazelcast.logging.LogEvent;
 
 public class SystemPrintLogger implements ILogger {
-	
+
 	private DateFormat format = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ssZ");
 
 	@Override

--- a/src/main/java/org/bitsofinfo/hazelcast/discovery/docker/swarm/test/DockerTestRunner.java
+++ b/src/main/java/org/bitsofinfo/hazelcast/discovery/docker/swarm/test/DockerTestRunner.java
@@ -1,8 +1,5 @@
 package org.bitsofinfo.hazelcast.discovery.docker.swarm.test;
 
-import org.bitsofinfo.hazelcast.discovery.docker.swarm.SwarmAddressPicker;
-import org.bitsofinfo.hazelcast.discovery.docker.swarm.SystemPrintLogger;
-
 import com.hazelcast.config.ClasspathXmlConfig;
 import com.hazelcast.config.Config;
 import com.hazelcast.core.HazelcastInstance;
@@ -11,6 +8,8 @@ import com.hazelcast.instance.DefaultNodeContext;
 import com.hazelcast.instance.HazelcastInstanceFactory;
 import com.hazelcast.instance.Node;
 import com.hazelcast.instance.NodeContext;
+import org.bitsofinfo.hazelcast.discovery.docker.swarm.SwarmAddressPicker;
+import org.bitsofinfo.hazelcast.discovery.docker.swarm.SystemPrintLogger;
 
 /**
  * Simple class for manually spawning hz instances and watching what happens

--- a/src/main/java/org/bitsofinfo/hazelcast/discovery/docker/swarm/test/DockerTestRunner.java
+++ b/src/main/java/org/bitsofinfo/hazelcast/discovery/docker/swarm/test/DockerTestRunner.java
@@ -15,52 +15,52 @@ import com.hazelcast.instance.NodeContext;
 /**
  * Simple class for manually spawning hz instances and watching what happens
  * as they discover one another
- * 
+ *
  * @author bitsofinfo
  *
  */
 public class DockerTestRunner {
 
 	public static void main(String[] args) throws Exception {
-		
-	
-		
+
+
+
 		if (System.getProperty("swarm-bind-method").equalsIgnoreCase("address-picker")) {
-			
+
 			Config conf =new ClasspathXmlConfig("hazelcast-docker-swarm-discovery-spi-example-address-picker.xml");
-			
+
 			NodeContext nodeContext = new DefaultNodeContext() {
-			    @Override
-			    public AddressPicker createAddressPicker(Node node) {
-			        return new SwarmAddressPicker(new SystemPrintLogger());
-			    }
+				@Override
+				public AddressPicker createAddressPicker(Node node) {
+					return new SwarmAddressPicker(new SystemPrintLogger());
+				}
 			};
-	
+
 			HazelcastInstance hazelcastInstance = HazelcastInstanceFactory
 					.newHazelcastInstance(conf,"hazelcast-docker-swarm-discovery-spi-example",nodeContext);
-			
-			
-			
+
+
+
 		} else if (System.getProperty("swarm-bind-method").equalsIgnoreCase("member-address-provider")) {
-			
+
 			Config conf =new ClasspathXmlConfig("hazelcast-docker-swarm-discovery-spi-example-member-address-provider.xml");
-			
-			
+
+
 			HazelcastInstance hazelcastInstance = HazelcastInstanceFactory
 					.newHazelcastInstance(conf,"hazelcast-docker-swarm-discovery-spi-example",new DefaultNodeContext());
 		} else if (System.getProperty("swarm-bind-method").equalsIgnoreCase("dockerDNSRR")) {
 			Config conf =
-				new ClasspathXmlConfig(
-					"hazelcast-docker-swarm-dnsrr-discovery-spi-example.xml"
-				);
+					new ClasspathXmlConfig(
+							"hazelcast-docker-swarm-dnsrr-discovery-spi-example.xml"
+					);
 
 			HazelcastInstance hazelcastInstance =
-				HazelcastInstanceFactory.newHazelcastInstance(conf);
+					HazelcastInstanceFactory.newHazelcastInstance(conf);
 		}
-		
-		
+
+
 		Thread.currentThread().sleep(400000);
-		
+
 		System.exit(0);
 	}
 }

--- a/src/main/java/org/bitsofinfo/hazelcast/spi/docker/swarm/dnsrr/DockerDNSRRMemberAddressProvider.java
+++ b/src/main/java/org/bitsofinfo/hazelcast/spi/docker/swarm/dnsrr/DockerDNSRRMemberAddressProvider.java
@@ -14,6 +14,10 @@
 
 package org.bitsofinfo.hazelcast.spi.docker.swarm.dnsrr;
 
+import com.hazelcast.logging.ILogger;
+import com.hazelcast.logging.Logger;
+import com.hazelcast.spi.MemberAddressProvider;
+
 import java.net.InetAddress;
 import java.net.InetSocketAddress;
 import java.net.NetworkInterface;
@@ -24,10 +28,6 @@ import java.util.Enumeration;
 import java.util.HashSet;
 import java.util.Properties;
 import java.util.Set;
-
-import com.hazelcast.logging.ILogger;
-import com.hazelcast.logging.Logger;
-import com.hazelcast.spi.MemberAddressProvider;
 
 /**
  * Member Address Provider for hazelcast that cross-references the service

--- a/src/main/java/org/bitsofinfo/hazelcast/spi/docker/swarm/dnsrr/DockerDNSRRMemberAddressProvider.java
+++ b/src/main/java/org/bitsofinfo/hazelcast/spi/docker/swarm/dnsrr/DockerDNSRRMemberAddressProvider.java
@@ -38,7 +38,7 @@ import com.hazelcast.spi.MemberAddressProvider;
  *
  */
 public class DockerDNSRRMemberAddressProvider
-    implements MemberAddressProvider
+        implements MemberAddressProvider
 {
     ILogger logger = Logger.getLogger(DockerDNSRRMemberAddressProvider.class);
 
@@ -46,7 +46,7 @@ public class DockerDNSRRMemberAddressProvider
     public static InetSocketAddress bindAddress = null;
 
     public DockerDNSRRMemberAddressProvider(Properties properties)
-        throws
+            throws
             NumberFormatException,
             SocketException,
             UnknownHostException
@@ -55,34 +55,34 @@ public class DockerDNSRRMemberAddressProvider
 
         if(properties != null) {
             String serviceName = properties.getProperty(
-                DockerDNSRRMemberAddressProviderConfig.SERVICENAME
+                    DockerDNSRRMemberAddressProviderConfig.SERVICENAME
             );
             String portString = properties.getProperty(
-                DockerDNSRRMemberAddressProviderConfig.SERVICEPORT
+                    DockerDNSRRMemberAddressProviderConfig.SERVICEPORT
             );
             Integer port = 5701;
 
             if (
-                portString != null &&
-                !"".equals(
-                    portString.trim()
-                )
+                    portString != null &&
+                            !"".equals(
+                                    portString.trim()
+                            )
             ) {
                 try {
                     port = Integer.valueOf(portString);
                 } catch(NumberFormatException nfe) {
                     logger.severe(
-                        "Unable to parse " +
-                        DockerDNSRRMemberAddressProviderConfig.SERVICEPORT +
-                        " with value " +
-                        portString
+                            "Unable to parse " +
+                                    DockerDNSRRMemberAddressProviderConfig.SERVICEPORT +
+                                    " with value " +
+                                    portString
                     );
                     throw nfe;
                 }
             }
 
             Set<InetAddress> potentialInetAddresses =
-                resolveServiceName(serviceName);
+                    resolveServiceName(serviceName);
 
             Enumeration<NetworkInterface> networkInterfaces;
             Enumeration<InetAddress> networkInterfaceAddresses;
@@ -92,11 +92,11 @@ public class DockerDNSRRMemberAddressProvider
                 networkInterfaces = NetworkInterface.getNetworkInterfaces();
 
                 while(
-                    networkInterfaces.hasMoreElements() &&
-                    bindAddress == null
+                        networkInterfaces.hasMoreElements() &&
+                                bindAddress == null
                 ) {
                     networkInterfaceAddresses =
-                        networkInterfaces.nextElement().getInetAddresses();
+                            networkInterfaces.nextElement().getInetAddresses();
 
                     while(networkInterfaceAddresses.hasMoreElements()) {
                         address = networkInterfaceAddresses.nextElement();
@@ -105,11 +105,11 @@ public class DockerDNSRRMemberAddressProvider
                         }
 
                         if(
-                            potentialInetAddresses.contains(address)
+                                potentialInetAddresses.contains(address)
                         ) {
                             bindAddress = new InetSocketAddress(
-                                address,
-                                port
+                                    address,
+                                    port
                             );
                             break;
                         }
@@ -117,7 +117,7 @@ public class DockerDNSRRMemberAddressProvider
                 }
             } catch (SocketException e) {
                 logger.severe(
-                    "Unable to bind socket: " + e.toString()
+                        "Unable to bind socket: " + e.toString()
                 );
                 throw e;
             }
@@ -126,7 +126,7 @@ public class DockerDNSRRMemberAddressProvider
     }
 
     private Set<InetAddress> resolveServiceName(String serviceName)
-        throws UnknownHostException
+            throws UnknownHostException
     {
         Set<InetAddress> addresses = new HashSet<InetAddress>();
 
@@ -135,16 +135,16 @@ public class DockerDNSRRMemberAddressProvider
             inetAddresses = InetAddress.getAllByName(serviceName);
 
             addresses.addAll(
-                Arrays.asList(inetAddresses)
+                    Arrays.asList(inetAddresses)
             );
 
             logger.info(
-                "Resolved domain name '" + serviceName +
-                    "' to address(es): " + addresses
+                    "Resolved domain name '" + serviceName +
+                            "' to address(es): " + addresses
             );
         } catch(UnknownHostException e) {
             logger.severe(
-                "Unable to resolve service name " + serviceName
+                    "Unable to resolve service name " + serviceName
             );
             throw e;
         }

--- a/src/main/java/org/bitsofinfo/hazelcast/spi/docker/swarm/dnsrr/DockerDNSRRMemberAddressProviderConfig.java
+++ b/src/main/java/org/bitsofinfo/hazelcast/spi/docker/swarm/dnsrr/DockerDNSRRMemberAddressProviderConfig.java
@@ -28,7 +28,7 @@ public class DockerDNSRRMemberAddressProviderConfig {
 
     /**
      * Property definition to load exposed port for hazelcast
-     * 
+     *
      * Note: This exists because MemberAddressProvider has no way to access
      *       the network configuration as of the time of writing this.
      */

--- a/src/main/java/org/bitsofinfo/hazelcast/spi/docker/swarm/dnsrr/discovery/DockerDNSRRDiscoveryConfiguration.java
+++ b/src/main/java/org/bitsofinfo/hazelcast/spi/docker/swarm/dnsrr/discovery/DockerDNSRRDiscoveryConfiguration.java
@@ -32,18 +32,18 @@ public class DockerDNSRRDiscoveryConfiguration {
      * Property definition to load CSV of services
      */
     public static final PropertyDefinition SERVICESCSV =
-        new SimplePropertyDefinition(
-            "peerServicesCsv",
-            PropertyTypeConverter.STRING
-        );
+            new SimplePropertyDefinition(
+                    "peerServicesCsv",
+                    PropertyTypeConverter.STRING
+            );
 
     /**
      * Full list of all properties referenced by this configuration
      */
     public static final Collection<PropertyDefinition> PROPERTIES =
-        Arrays.asList(
-            new PropertyDefinition[] {
-                SERVICESCSV
-            }
-        );
+            Arrays.asList(
+                    new PropertyDefinition[] {
+                            SERVICESCSV
+                    }
+            );
 }

--- a/src/main/java/org/bitsofinfo/hazelcast/spi/docker/swarm/dnsrr/discovery/DockerDNSRRDiscoveryConfiguration.java
+++ b/src/main/java/org/bitsofinfo/hazelcast/spi/docker/swarm/dnsrr/discovery/DockerDNSRRDiscoveryConfiguration.java
@@ -14,12 +14,12 @@
 
 package org.bitsofinfo.hazelcast.spi.docker.swarm.dnsrr.discovery;
 
-import java.util.Arrays;
-import java.util.Collection;
-
 import com.hazelcast.config.properties.PropertyDefinition;
 import com.hazelcast.config.properties.PropertyTypeConverter;
 import com.hazelcast.config.properties.SimplePropertyDefinition;
+
+import java.util.Arrays;
+import java.util.Collection;
 
 /**
  * Configuration required for <code>DockerDNSRRDiscoveryStrategy</code>

--- a/src/main/java/org/bitsofinfo/hazelcast/spi/docker/swarm/dnsrr/discovery/DockerDNSRRDiscoveryStrategy.java
+++ b/src/main/java/org/bitsofinfo/hazelcast/spi/docker/swarm/dnsrr/discovery/DockerDNSRRDiscoveryStrategy.java
@@ -14,6 +14,12 @@
 
 package org.bitsofinfo.hazelcast.spi.docker.swarm.dnsrr.discovery;
 
+import com.hazelcast.logging.ILogger;
+import com.hazelcast.nio.Address;
+import com.hazelcast.spi.discovery.AbstractDiscoveryStrategy;
+import com.hazelcast.spi.discovery.DiscoveryNode;
+import com.hazelcast.spi.discovery.SimpleDiscoveryNode;
+
 import java.net.InetAddress;
 import java.net.UnknownHostException;
 import java.util.Arrays;
@@ -21,12 +27,6 @@ import java.util.HashSet;
 import java.util.LinkedList;
 import java.util.Map;
 import java.util.Set;
-
-import com.hazelcast.logging.ILogger;
-import com.hazelcast.nio.Address;
-import com.hazelcast.spi.discovery.AbstractDiscoveryStrategy;
-import com.hazelcast.spi.discovery.DiscoveryNode;
-import com.hazelcast.spi.discovery.SimpleDiscoveryNode;
 
 /**
  * Hazelcast discovery strategy to be used with docker endpoint_mode: dnsrr

--- a/src/main/java/org/bitsofinfo/hazelcast/spi/docker/swarm/dnsrr/discovery/DockerDNSRRDiscoveryStrategy.java
+++ b/src/main/java/org/bitsofinfo/hazelcast/spi/docker/swarm/dnsrr/discovery/DockerDNSRRDiscoveryStrategy.java
@@ -37,15 +37,15 @@ import com.hazelcast.spi.discovery.SimpleDiscoveryNode;
  *
  */
 public class DockerDNSRRDiscoveryStrategy
-    extends AbstractDiscoveryStrategy
+        extends AbstractDiscoveryStrategy
 {
     private ILogger logger;
 
     public DockerDNSRRDiscoveryStrategy(
-        ILogger logger,
-        //The Comparable raw type is defined by AbstractDiscoveryStrategy as
-        //the value for the properties element; passing through here
-        @SuppressWarnings("rawtypes") Map<String, Comparable> properties
+            ILogger logger,
+            //The Comparable raw type is defined by AbstractDiscoveryStrategy as
+            //the value for the properties element; passing through here
+            @SuppressWarnings("rawtypes") Map<String, Comparable> properties
     ) {
         super(logger, properties);
         this.logger = logger;
@@ -54,24 +54,24 @@ public class DockerDNSRRDiscoveryStrategy
     @Override
     public Iterable<DiscoveryNode> discoverNodes() {
         LinkedList<DiscoveryNode> discoveryNodes =
-            new LinkedList<DiscoveryNode>();
+                new LinkedList<DiscoveryNode>();
 
         //Pull properties
         String servicesCsv = getOrDefault(
-            DockerDNSRRDiscoveryConfiguration.SERVICESCSV,
-            ""
+                DockerDNSRRDiscoveryConfiguration.SERVICESCSV,
+                ""
         );
 
         //If there are no services configured, no point in doing anything.
         if(
-            servicesCsv == null ||
-            servicesCsv.trim().isEmpty()
+                servicesCsv == null ||
+                        servicesCsv.trim().isEmpty()
         ) {
             return discoveryNodes;
         }
 
         Set<InetAddress> serviceNameResolutions =
-            new HashSet<InetAddress>();
+                new HashSet<InetAddress>();
         String[] serviceHostnameAndPort;
         Integer port = 5701;
 
@@ -83,33 +83,33 @@ public class DockerDNSRRDiscoveryStrategy
 
                 //Validate hostname exists
                 if (
-                    serviceHostnameAndPort[0] == null ||
-                    serviceHostnameAndPort[0].trim().isEmpty()
+                        serviceHostnameAndPort[0] == null ||
+                                serviceHostnameAndPort[0].trim().isEmpty()
                 ) {
                     logger.info(
-                        "Unable to resolve service hostname " +
-                            serviceHostnameAndPort[0] +
-                            " Skipping service entry."
+                            "Unable to resolve service hostname " +
+                                    serviceHostnameAndPort[0] +
+                                    " Skipping service entry."
                     );
                     continue;
                 }
                 //Validate port exists; assume default port if it doesn't
                 if (
-                    serviceHostnameAndPort.length <= 1 ||
-                    serviceHostnameAndPort[1] == null ||
-                    serviceHostnameAndPort[1].trim().isEmpty()
+                        serviceHostnameAndPort.length <= 1 ||
+                                serviceHostnameAndPort[1] == null ||
+                                serviceHostnameAndPort[1].trim().isEmpty()
                 ) {
                     port = 5701;
                 } else {
                     try {
                         port = Integer.valueOf(
-                            serviceHostnameAndPort[1]
+                                serviceHostnameAndPort[1]
                         );
                     } catch(NumberFormatException nfe) {
                         logger.info(
-                            "Unable to parse port " +
-                                serviceHostnameAndPort[1] +
-                                " Skipping service entry."
+                                "Unable to parse port " +
+                                        serviceHostnameAndPort[1] +
+                                        " Skipping service entry."
                         );
                         continue;
                     }
@@ -117,19 +117,19 @@ public class DockerDNSRRDiscoveryStrategy
 
                 //Resolve service hostname to a set of IP addresses, if any
                 serviceNameResolutions =
-                    resolveDomainNames(
-                        serviceHostnameAndPort[0]
-                    );
+                        resolveDomainNames(
+                                serviceHostnameAndPort[0]
+                        );
 
                 //Add all IP addresses for service hostname with the given port.
                 for(InetAddress resolution: serviceNameResolutions) {
                     discoveryNodes.add(
-                        new SimpleDiscoveryNode(
-                            new Address(
-                                resolution,
-                                port
+                            new SimpleDiscoveryNode(
+                                    new Address(
+                                            resolution,
+                                            port
+                                    )
                             )
-                        )
                     );
                 }
             }
@@ -146,15 +146,15 @@ public class DockerDNSRRDiscoveryStrategy
             inetAddresses = InetAddress.getAllByName(domainName);
 
             addresses.addAll(
-                Arrays.asList(inetAddresses)
+                    Arrays.asList(inetAddresses)
             );
 
             logger.info(
-                "Resolved domain name '" + domainName + "' to address(es): " + addresses
+                    "Resolved domain name '" + domainName + "' to address(es): " + addresses
             );
         } catch(UnknownHostException e) {
             logger.severe(
-                "Unable to resolve domain name " + domainName
+                    "Unable to resolve domain name " + domainName
             );
         }
 

--- a/src/main/java/org/bitsofinfo/hazelcast/spi/docker/swarm/dnsrr/discovery/DockerDNSRRDiscoveryStrategyFactory.java
+++ b/src/main/java/org/bitsofinfo/hazelcast/spi/docker/swarm/dnsrr/discovery/DockerDNSRRDiscoveryStrategyFactory.java
@@ -14,14 +14,14 @@
 
 package org.bitsofinfo.hazelcast.spi.docker.swarm.dnsrr.discovery;
 
-import java.util.Collection;
-import java.util.Map;
-
 import com.hazelcast.config.properties.PropertyDefinition;
 import com.hazelcast.logging.ILogger;
 import com.hazelcast.spi.discovery.DiscoveryNode;
 import com.hazelcast.spi.discovery.DiscoveryStrategy;
 import com.hazelcast.spi.discovery.DiscoveryStrategyFactory;
+
+import java.util.Collection;
+import java.util.Map;
 
 /**
  * Factory to produce <code>DockerDNSRRDiscoveryStrategy</code>

--- a/src/main/java/org/bitsofinfo/hazelcast/spi/docker/swarm/dnsrr/discovery/DockerDNSRRDiscoveryStrategyFactory.java
+++ b/src/main/java/org/bitsofinfo/hazelcast/spi/docker/swarm/dnsrr/discovery/DockerDNSRRDiscoveryStrategyFactory.java
@@ -30,7 +30,7 @@ import com.hazelcast.spi.discovery.DiscoveryStrategyFactory;
  *
  */
 public class DockerDNSRRDiscoveryStrategyFactory
-    implements DiscoveryStrategyFactory
+        implements DiscoveryStrategyFactory
 {
     @Override
     public Class<? extends DiscoveryStrategy> getDiscoveryStrategyType() {
@@ -39,16 +39,16 @@ public class DockerDNSRRDiscoveryStrategyFactory
 
     @Override
     public DiscoveryStrategy newDiscoveryStrategy(
-        DiscoveryNode discoveryNode,
-        ILogger logger,
-        //Implementing DiscoveryStrategyFactory method with a raw type
-        @SuppressWarnings("rawtypes") Map<String, Comparable> properties
+            DiscoveryNode discoveryNode,
+            ILogger logger,
+            //Implementing DiscoveryStrategyFactory method with a raw type
+            @SuppressWarnings("rawtypes") Map<String, Comparable> properties
     ) {
         return
-            new DockerDNSRRDiscoveryStrategy(
-                logger,
-                properties
-            );
+                new DockerDNSRRDiscoveryStrategy(
+                        logger,
+                        properties
+                );
     }
 
     @Override


### PR DESCRIPTION
I have harmonised indentation at 4-spaces and run an Optimize Imports inspection.  I configured Optimize Imports not to use *, since you seem to use explicit imports consistently; net effect is that any unused imports would have been removed and the order in which imports appear would have been set deterministically.

Doing these two things delivers a PR which is entirely non-functional.  If you approve and merge this, then I'd like to do a few other items of tidy-up.  Getting whitespace and imports sorted is a prerequisite (or you will not be able to see the wood for the trees when reviewing other items).