### PR TITLE
Five refactorings

### DIFF
--- a/src/main/java/org/bitsofinfo/hazelcast/discovery/docker/swarm/SystemPrintLogger.java
+++ b/src/main/java/org/bitsofinfo/hazelcast/discovery/docker/swarm/SystemPrintLogger.java
@@ -8,7 +8,7 @@ import java.text.SimpleDateFormat;
 import java.util.logging.Level;
 import java.util.logging.LogRecord;
 
-//@SuppressWarnings("squid:S106")
+@SuppressWarnings("squid:S106")
 public class SystemPrintLogger implements ILogger {
 
     @Override

--- a/src/main/java/org/bitsofinfo/hazelcast/discovery/docker/swarm/SystemPrintLogger.java
+++ b/src/main/java/org/bitsofinfo/hazelcast/discovery/docker/swarm/SystemPrintLogger.java
@@ -10,8 +10,6 @@ import java.util.logging.LogRecord;
 
 public class SystemPrintLogger implements ILogger {
 
-    private DateFormat format = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ssZ");
-
     @Override
     public void finest(String message) {
         System.out.println("FINEST " + message);

--- a/src/main/java/org/bitsofinfo/hazelcast/discovery/docker/swarm/SystemPrintLogger.java
+++ b/src/main/java/org/bitsofinfo/hazelcast/discovery/docker/swarm/SystemPrintLogger.java
@@ -8,6 +8,7 @@ import java.text.SimpleDateFormat;
 import java.util.logging.Level;
 import java.util.logging.LogRecord;
 
+//@SuppressWarnings("squid:S106")
 public class SystemPrintLogger implements ILogger {
 
     @Override

--- a/src/main/java/org/bitsofinfo/hazelcast/discovery/docker/swarm/test/DockerTestRunner.java
+++ b/src/main/java/org/bitsofinfo/hazelcast/discovery/docker/swarm/test/DockerTestRunner.java
@@ -2,7 +2,6 @@ package org.bitsofinfo.hazelcast.discovery.docker.swarm.test;
 
 import com.hazelcast.config.ClasspathXmlConfig;
 import com.hazelcast.config.Config;
-import com.hazelcast.core.HazelcastInstance;
 import com.hazelcast.instance.AddressPicker;
 import com.hazelcast.instance.DefaultNodeContext;
 import com.hazelcast.instance.HazelcastInstanceFactory;

--- a/src/main/java/org/bitsofinfo/hazelcast/discovery/docker/swarm/test/DockerTestRunner.java
+++ b/src/main/java/org/bitsofinfo/hazelcast/discovery/docker/swarm/test/DockerTestRunner.java
@@ -33,7 +33,7 @@ public class DockerTestRunner {
                 }
             };
 
-            HazelcastInstance hazelcastInstance = HazelcastInstanceFactory
+            HazelcastInstanceFactory
                     .newHazelcastInstance(conf, "hazelcast-docker-swarm-discovery-spi-example", nodeContext);
 
 
@@ -42,7 +42,7 @@ public class DockerTestRunner {
             Config conf = new ClasspathXmlConfig("hazelcast-docker-swarm-discovery-spi-example-member-address-provider.xml");
 
 
-            HazelcastInstance hazelcastInstance = HazelcastInstanceFactory
+            HazelcastInstanceFactory
                     .newHazelcastInstance(conf, "hazelcast-docker-swarm-discovery-spi-example", new DefaultNodeContext());
         } else if (System.getProperty("swarm-bind-method").equalsIgnoreCase("dockerDNSRR")) {
             Config conf =
@@ -50,8 +50,7 @@ public class DockerTestRunner {
                             "hazelcast-docker-swarm-dnsrr-discovery-spi-example.xml"
                     );
 
-            HazelcastInstance hazelcastInstance =
-                    HazelcastInstanceFactory.newHazelcastInstance(conf);
+            HazelcastInstanceFactory.newHazelcastInstance(conf);
         }
 
 

--- a/src/main/java/org/bitsofinfo/hazelcast/spi/docker/swarm/dnsrr/DockerDNSRRMemberAddressProvider.java
+++ b/src/main/java/org/bitsofinfo/hazelcast/spi/docker/swarm/dnsrr/DockerDNSRRMemberAddressProvider.java
@@ -38,8 +38,8 @@ import java.util.Set;
  */
 public class DockerDNSRRMemberAddressProvider
         implements MemberAddressProvider {
-    public static Properties properties;
-    public static InetSocketAddress bindAddress = null;
+    protected Properties properties;
+    protected InetSocketAddress bindAddress = null;
     ILogger logger = Logger.getLogger(DockerDNSRRMemberAddressProvider.class);
 
     public DockerDNSRRMemberAddressProvider(Properties properties)
@@ -47,7 +47,7 @@ public class DockerDNSRRMemberAddressProvider
             NumberFormatException,
             SocketException,
             UnknownHostException {
-        DockerDNSRRMemberAddressProvider.properties = properties;
+        this.properties = properties;
 
         if (properties != null) {
             String serviceName = properties.getProperty(

--- a/src/main/java/org/bitsofinfo/hazelcast/spi/docker/swarm/dnsrr/DockerDNSRRMemberAddressProvider.java
+++ b/src/main/java/org/bitsofinfo/hazelcast/spi/docker/swarm/dnsrr/DockerDNSRRMemberAddressProvider.java
@@ -42,9 +42,15 @@ public class DockerDNSRRMemberAddressProvider
     protected InetSocketAddress bindAddress = null;
     ILogger logger = Logger.getLogger(DockerDNSRRMemberAddressProvider.class);
 
+    /**
+     *
+     * @param properties
+     * @throws NumberFormatException if servicePort cannot be parsed
+     * @throws SocketException
+     * @throws UnknownHostException
+     */
     public DockerDNSRRMemberAddressProvider(Properties properties)
             throws
-            NumberFormatException,
             SocketException,
             UnknownHostException {
         this.properties = properties;

--- a/src/main/java/org/bitsofinfo/hazelcast/spi/docker/swarm/dnsrr/discovery/DockerDNSRRDiscoveryStrategy.java
+++ b/src/main/java/org/bitsofinfo/hazelcast/spi/docker/swarm/dnsrr/discovery/DockerDNSRRDiscoveryStrategy.java
@@ -68,10 +68,10 @@ public class DockerDNSRRDiscoveryStrategy
             return discoveryNodes;
         }
 
-        Set<InetAddress> serviceNameResolutions =
-                new HashSet<>();
+        // TODO robin - tighten scope of these variables
+        Set<InetAddress> serviceNameResolutions;
         String[] serviceHostnameAndPort;
-        Integer port = 5701;
+        Integer port;
 
         //Loop for every service defined in the CSV
         for (String service : servicesCsv.split(",")) {


### PR DESCRIPTION
Five refactorings:
* ”throws" declarations should not be superfluous
* Static fields should not be updated in constructors (in this case the fields should not be static)
* Unused "private" fields should be removed
* Optimize Imports
* Standard outputs should not be used directly to log anything (in this case suppress the warning since logging "to stdout" is the express purpose of the class SystemPrintLogger)
